### PR TITLE
feat: add Akka.NET best practices and hosting patterns skills

### DIFF
--- a/skills/akka-hosting-actor-patterns.md
+++ b/skills/akka-hosting-actor-patterns.md
@@ -1,0 +1,412 @@
+---
+name: akka-hosting-actor-patterns
+description: Patterns for building entity actors with Akka.Hosting - GenericChildPerEntityParent, message extractors, cluster sharding abstraction, akka-reminders, and ITimeProvider. Supports both local testing and clustered production modes.
+---
+
+# Akka.Hosting Actor Patterns
+
+## When to Use This Skill
+
+Use this skill when:
+- Building entity actors that represent domain objects (users, orders, invoices, etc.)
+- Need actors that work in both unit tests (no clustering) and production (cluster sharding)
+- Setting up scheduled tasks with akka-reminders
+- Registering actors with Akka.Hosting extension methods
+- Creating reusable actor configuration patterns
+
+## Core Principles
+
+1. **Execution Mode Abstraction** - Same actor code runs locally (tests) or clustered (production)
+2. **GenericChildPerEntityParent for Local** - Mimics sharding semantics without cluster overhead
+3. **Message Extractors for Routing** - Reuse Akka.Cluster.Sharding's IMessageExtractor interface
+4. **Akka.Hosting Extension Methods** - Fluent configuration that composes well
+5. **ITimeProvider for Testability** - Use ActorSystem.Scheduler instead of DateTime.Now
+
+## Execution Modes
+
+Define an enum to control actor behavior:
+
+```csharp
+/// <summary>
+/// Determines how Akka.NET should be configured
+/// </summary>
+public enum AkkaExecutionMode
+{
+    /// <summary>
+    /// Pure local actor system - no remoting, no clustering.
+    /// Use GenericChildPerEntityParent instead of ShardRegion.
+    /// Ideal for unit tests and simple scenarios.
+    /// </summary>
+    LocalTest,
+
+    /// <summary>
+    /// Full clustering with ShardRegion.
+    /// Use for integration testing and production.
+    /// </summary>
+    Clustered
+}
+```
+
+## GenericChildPerEntityParent
+
+A lightweight parent actor that routes messages to child entities, mimicking cluster sharding semantics without requiring a cluster:
+
+```csharp
+using Akka.Actor;
+using Akka.Cluster.Sharding;
+
+/// <summary>
+/// A generic "child per entity" parent actor.
+/// </summary>
+/// <remarks>
+/// Reuses Akka.Cluster.Sharding's IMessageExtractor for consistent routing.
+/// Ideal for unit tests where clustering overhead is unnecessary.
+/// </remarks>
+public sealed class GenericChildPerEntityParent : ReceiveActor
+{
+    public static Props CreateProps(
+        IMessageExtractor extractor,
+        Func<string, Props> propsFactory)
+    {
+        return Props.Create(() =>
+            new GenericChildPerEntityParent(extractor, propsFactory));
+    }
+
+    private readonly IMessageExtractor _extractor;
+    private readonly Func<string, Props> _propsFactory;
+
+    public GenericChildPerEntityParent(
+        IMessageExtractor extractor,
+        Func<string, Props> propsFactory)
+    {
+        _extractor = extractor;
+        _propsFactory = propsFactory;
+
+        ReceiveAny(message =>
+        {
+            var entityId = _extractor.EntityId(message);
+            if (entityId is null) return;
+
+            // Get existing child or create new one
+            Context.Child(entityId)
+                .GetOrElse(() => Context.ActorOf(_propsFactory(entityId), entityId))
+                .Forward(_extractor.EntityMessage(message));
+        });
+    }
+}
+```
+
+## Message Extractors
+
+Create extractors that implement `IMessageExtractor` from Akka.Cluster.Sharding:
+
+```csharp
+using Akka.Cluster.Sharding;
+
+/// <summary>
+/// Routes messages to entity actors based on a strongly-typed ID.
+/// </summary>
+public sealed class OrderMessageExtractor : HashCodeMessageExtractor
+{
+    public const int DefaultShardCount = 40;
+
+    public OrderMessageExtractor(int maxNumberOfShards = DefaultShardCount)
+        : base(maxNumberOfShards)
+    {
+    }
+
+    public override string? EntityId(object message)
+    {
+        return message switch
+        {
+            IWithOrderId msg => msg.OrderId.Value.ToString(),
+            _ => null
+        };
+    }
+}
+
+// Define an interface for messages that target a specific entity
+public interface IWithOrderId
+{
+    OrderId OrderId { get; }
+}
+
+// Use strongly-typed IDs
+public readonly record struct OrderId(Guid Value)
+{
+    public static OrderId New() => new(Guid.NewGuid());
+    public override string ToString() => Value.ToString();
+}
+```
+
+## Akka.Hosting Extension Methods
+
+Create extension methods that abstract the execution mode:
+
+```csharp
+using Akka.Cluster.Hosting;
+using Akka.Cluster.Sharding;
+using Akka.Hosting;
+
+public static class OrderActorHostingExtensions
+{
+    /// <summary>
+    /// Adds OrderActor with support for both local and clustered modes.
+    /// </summary>
+    public static AkkaConfigurationBuilder WithOrderActor(
+        this AkkaConfigurationBuilder builder,
+        AkkaExecutionMode executionMode = AkkaExecutionMode.Clustered,
+        string? clusterRole = null)
+    {
+        if (executionMode == AkkaExecutionMode.LocalTest)
+        {
+            // Non-clustered mode: Use GenericChildPerEntityParent
+            builder.WithActors((system, registry, resolver) =>
+            {
+                var parent = system.ActorOf(
+                    GenericChildPerEntityParent.CreateProps(
+                        new OrderMessageExtractor(),
+                        entityId => resolver.Props<OrderActor>(entityId)),
+                    "orders");
+
+                registry.Register<OrderActor>(parent);
+            });
+        }
+        else
+        {
+            // Clustered mode: Use ShardRegion
+            builder.WithShardRegion<OrderActor>(
+                "orders",
+                (system, registry, resolver) =>
+                    entityId => resolver.Props<OrderActor>(entityId),
+                new OrderMessageExtractor(),
+                new ShardOptions
+                {
+                    StateStoreMode = StateStoreMode.DData,
+                    Role = clusterRole
+                });
+        }
+
+        return builder;
+    }
+}
+```
+
+## Composing Multiple Actors
+
+Create a convenience method that registers all domain actors:
+
+```csharp
+public static class DomainActorHostingExtensions
+{
+    /// <summary>
+    /// Adds all order domain actors with sharding support.
+    /// </summary>
+    public static AkkaConfigurationBuilder WithOrderDomainActors(
+        this AkkaConfigurationBuilder builder,
+        AkkaExecutionMode executionMode = AkkaExecutionMode.Clustered,
+        string? clusterRole = null)
+    {
+        return builder
+            .WithOrderActor(executionMode, clusterRole)
+            .WithPaymentActor(executionMode, clusterRole)
+            .WithShipmentActor(executionMode, clusterRole)
+            .WithNotificationActor(); // Singleton, no sharding needed
+    }
+}
+```
+
+## Using ITimeProvider for Scheduling
+
+Register the ActorSystem's Scheduler as an `ITimeProvider` for testable time-based logic:
+
+```csharp
+public static class SharedAkkaHostingExtensions
+{
+    public static IServiceCollection AddAkkaWithTimeProvider(
+        this IServiceCollection services,
+        Action<AkkaConfigurationBuilder, IServiceProvider> configure)
+    {
+        // Register ITimeProvider using the ActorSystem's Scheduler
+        services.AddSingleton<ITimeProvider>(sp =>
+            sp.GetRequiredService<ActorSystem>().Scheduler);
+
+        return services.ConfigureAkka((builder, sp) =>
+        {
+            configure(builder, sp);
+        });
+    }
+}
+
+// In your actor, inject ITimeProvider
+public class SubscriptionActor : ReceiveActor
+{
+    private readonly ITimeProvider _timeProvider;
+
+    public SubscriptionActor(ITimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+
+        // Use _timeProvider.GetUtcNow() instead of DateTime.UtcNow
+        // This allows tests to control time
+    }
+}
+```
+
+## Akka.Reminders Integration
+
+For durable scheduled tasks that survive restarts, use akka-reminders:
+
+```csharp
+using Akka.Reminders;
+using Akka.Reminders.Sql;
+using Akka.Reminders.Sql.Configuration;
+using Akka.Reminders.Storage;
+
+public static class ReminderHostingExtensions
+{
+    /// <summary>
+    /// Configures akka-reminders with PostgreSQL storage.
+    /// </summary>
+    public static AkkaConfigurationBuilder WithPostgresReminders(
+        this AkkaConfigurationBuilder builder,
+        string connectionString,
+        string schemaName = "reminders",
+        string tableName = "scheduled_reminders",
+        bool autoInitialize = true)
+    {
+        return builder.WithLocalReminders(reminders => reminders
+            .WithResolver(sys => new GenericChildPerEntityResolver(sys))
+            .WithStorage(system =>
+            {
+                var settings = SqlReminderStorageSettings.CreatePostgreSql(
+                    connectionString,
+                    schemaName,
+                    tableName,
+                    autoInitialize);
+                return new SqlReminderStorage(settings, system);
+            })
+            .WithSettings(new ReminderSettings
+            {
+                MaxSlippage = TimeSpan.FromSeconds(30),
+                MaxDeliveryAttempts = 3,
+                RetryBackoffBase = TimeSpan.FromSeconds(10)
+            }));
+    }
+
+    /// <summary>
+    /// Configures akka-reminders with in-memory storage for testing.
+    /// </summary>
+    public static AkkaConfigurationBuilder WithInMemoryReminders(
+        this AkkaConfigurationBuilder builder)
+    {
+        return builder.WithLocalReminders(reminders => reminders
+            .WithResolver(sys => new GenericChildPerEntityResolver(sys))
+            .WithStorage(system => new InMemoryReminderStorage())
+            .WithSettings(new ReminderSettings
+            {
+                MaxSlippage = TimeSpan.FromSeconds(1),
+                MaxDeliveryAttempts = 3,
+                RetryBackoffBase = TimeSpan.FromMilliseconds(100)
+            }));
+    }
+}
+```
+
+### Custom Reminder Resolver for Child-Per-Entity
+
+Route reminder callbacks to GenericChildPerEntityParent actors:
+
+```csharp
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Reminders;
+
+/// <summary>
+/// Resolves reminder targets to GenericChildPerEntityParent actors.
+/// </summary>
+public sealed class GenericChildPerEntityResolver : IReminderActorResolver
+{
+    private readonly ActorSystem _system;
+
+    public GenericChildPerEntityResolver(ActorSystem system)
+    {
+        _system = system;
+    }
+
+    public IActorRef ResolveActorRef(ReminderEntry entry)
+    {
+        var registry = ActorRegistry.For(_system);
+
+        return entry.Key switch
+        {
+            var k when k.StartsWith("order-") =>
+                registry.Get<OrderActor>(),
+            var k when k.StartsWith("subscription-") =>
+                registry.Get<SubscriptionActor>(),
+            _ => throw new InvalidOperationException(
+                $"Unknown reminder key format: {entry.Key}")
+        };
+    }
+}
+```
+
+## Singleton Actors (Not Sharded)
+
+For actors that should only have one instance:
+
+```csharp
+public static AkkaConfigurationBuilder WithEmailSenderActor(
+    this AkkaConfigurationBuilder builder)
+{
+    return builder.WithActors((system, registry, resolver) =>
+    {
+        var actor = system.ActorOf(
+            resolver.Props<EmailSenderActor>(),
+            "email-sender");
+        registry.Register<EmailSenderActor>(actor);
+    });
+}
+```
+
+## Marker Types for Registry
+
+When you need to reference actors that are registered as parents:
+
+```csharp
+/// <summary>
+/// Marker type for ActorRegistry to retrieve the order manager
+/// (GenericChildPerEntityParent for OrderActors).
+/// </summary>
+public sealed class OrderManagerActor;
+
+// Usage in extension method
+registry.Register<OrderManagerActor>(parent);
+
+// Usage in controller/service
+public class OrderService
+{
+    private readonly IActorRef _orderManager;
+
+    public OrderService(IRequiredActor<OrderManagerActor> orderManager)
+    {
+        _orderManager = orderManager.ActorRef;
+    }
+
+    public async Task<OrderResponse> CreateOrder(CreateOrderCommand cmd)
+    {
+        return await _orderManager.Ask<OrderResponse>(cmd);
+    }
+}
+```
+
+## Best Practices
+
+1. **Always support both execution modes** - Makes testing easy without code changes
+2. **Use strongly-typed IDs** - `OrderId` instead of `string` or `Guid`
+3. **Interface-based message routing** - `IWithOrderId` for type-safe extraction
+4. **Register parent, not children** - For child-per-entity, register the parent in ActorRegistry
+5. **Marker types for clarity** - Use empty marker classes for registry lookups
+6. **Composition over inheritance** - Chain extension methods, don't create deep hierarchies
+7. **ITimeProvider for scheduling** - Never use `DateTime.Now` directly in actors
+8. **akka-reminders for durability** - Use for scheduled tasks that must survive restarts

--- a/skills/akka-net-best-practices.md
+++ b/skills/akka-net-best-practices.md
@@ -1,0 +1,578 @@
+---
+name: akka-net-best-practices
+description: Critical Akka.NET best practices including EventStream vs DistributedPubSub, supervision strategy clarifications, error handling patterns, Props vs DependencyResolver, and work distribution patterns.
+---
+
+# Akka.NET Best Practices
+
+## When to Use This Skill
+
+Use this skill when:
+- Designing actor communication patterns
+- Deciding between EventStream and DistributedPubSub
+- Implementing error handling in actors
+- Understanding supervision strategies
+- Choosing between Props patterns and DependencyResolver
+- Designing work distribution across nodes
+
+---
+
+## 1. EventStream vs DistributedPubSub
+
+### Critical: EventStream is LOCAL ONLY
+
+`Context.System.EventStream` is **local to a single ActorSystem process**. It does NOT work across cluster nodes.
+
+```csharp
+// BAD: This only works on a single server
+// When you add a second server, subscribers on server 2 won't receive events from server 1
+Context.System.EventStream.Subscribe(Self, typeof(PostCreated));
+Context.System.EventStream.Publish(new PostCreated(postId, authorId));
+```
+
+**When EventStream is appropriate:**
+- Logging and diagnostics within a single process
+- Local event bus for truly single-process applications
+- Development/testing scenarios
+
+### Use DistributedPubSub for Multi-Node
+
+For events that must reach actors across multiple cluster nodes, use `Akka.Cluster.Tools.PublishSubscribe`:
+
+```csharp
+using Akka.Cluster.Tools.PublishSubscribe;
+
+public class TimelineUpdatePublisher : ReceiveActor
+{
+    private readonly IActorRef _mediator;
+
+    public TimelineUpdatePublisher()
+    {
+        // Get the DistributedPubSub mediator
+        _mediator = DistributedPubSub.Get(Context.System).Mediator;
+
+        Receive<PublishTimelineUpdate>(msg =>
+        {
+            // Publish to a topic - reaches all subscribers across all nodes
+            _mediator.Tell(new Publish($"timeline:{msg.UserId}", msg.Update));
+        });
+    }
+}
+
+public class TimelineSubscriber : ReceiveActor
+{
+    public TimelineSubscriber(UserId userId)
+    {
+        var mediator = DistributedPubSub.Get(Context.System).Mediator;
+
+        // Subscribe to user-specific topic
+        mediator.Tell(new Subscribe($"timeline:{userId}", Self));
+
+        Receive<TimelineUpdate>(update =>
+        {
+            // Handle the update - this works across cluster nodes
+        });
+
+        Receive<SubscribeAck>(ack =>
+        {
+            // Subscription confirmed
+        });
+    }
+}
+```
+
+### Akka.Hosting Configuration for DistributedPubSub
+
+```csharp
+builder.WithDistributedPubSub(role: null); // Available on all roles, or specify a role
+```
+
+### Topic Design Patterns
+
+| Pattern | Topic Format | Use Case |
+|---------|--------------|----------|
+| Per-user | `timeline:{userId}` | Timeline updates, notifications |
+| Per-entity | `post:{postId}` | Post engagement updates |
+| Broadcast | `system:announcements` | System-wide notifications |
+| Role-based | `workers:rss-poller` | Work distribution |
+
+---
+
+## 2. Supervision Strategies
+
+### Key Clarification: Supervision is for CHILDREN
+
+A supervision strategy defined on an actor dictates **how that actor supervises its children**, NOT how the actor itself is supervised.
+
+```csharp
+public class ParentActor : ReceiveActor
+{
+    // This strategy applies to children of ParentActor, NOT to ParentActor itself
+    protected override SupervisorStrategy SupervisorStrategy()
+    {
+        return new OneForOneStrategy(
+            maxNrOfRetries: 10,
+            withinTimeRange: TimeSpan.FromSeconds(30),
+            decider: ex => ex switch
+            {
+                ArithmeticException => Directive.Resume,
+                NullReferenceException => Directive.Restart,
+                ArgumentException => Directive.Stop,
+                _ => Directive.Escalate
+            });
+    }
+}
+```
+
+### Default Supervision Strategy
+
+The default `OneForOneStrategy` already includes rate limiting:
+- **10 restarts within 1 second** = actor is permanently stopped
+- This prevents infinite restart loops
+
+**You rarely need a custom strategy** unless you have specific requirements.
+
+### When to Define Custom Supervision
+
+**Good reasons:**
+- Actor throws exceptions indicating irrecoverable state corruption → Restart
+- Actor throws exceptions that should NOT cause restart (expected failures) → Resume
+- Child failures should affect siblings → Use `AllForOneStrategy`
+- Need different retry limits than the default
+
+**Bad reasons:**
+- "Just to be safe" - the default is already safe
+- Don't understand what the actor does - understand it first
+
+### Example: When Custom Supervision Makes Sense
+
+```csharp
+public class RssFeedCoordinator : ReceiveActor
+{
+    protected override SupervisorStrategy SupervisorStrategy()
+    {
+        return new OneForOneStrategy(
+            maxNrOfRetries: -1, // Unlimited retries
+            withinTimeRange: TimeSpan.FromMinutes(1),
+            decider: ex => ex switch
+            {
+                // HTTP timeout - transient, resume and let the actor retry via its own timer
+                HttpRequestException => Directive.Resume,
+
+                // Feed URL permanently invalid - stop this child, don't restart forever
+                InvalidFeedUrlException => Directive.Stop,
+
+                // Unknown error - restart to clear potentially corrupt state
+                _ => Directive.Restart
+            });
+    }
+}
+```
+
+---
+
+## 3. Error Handling: Supervision vs Try-Catch
+
+### When to Use Try-Catch (Most Cases)
+
+**Use try-catch when:**
+- The failure is **expected** (network timeout, invalid input, external service down)
+- You know **exactly why** the exception occurred
+- You can handle it **gracefully** (retry, return error response, log and continue)
+- Restarting would **not help** (same error would occur again)
+
+```csharp
+public class RssFeedPollerActor : ReceiveActor
+{
+    public RssFeedPollerActor()
+    {
+        ReceiveAsync<PollFeed>(async msg =>
+        {
+            try
+            {
+                var feed = await _httpClient.GetStringAsync(msg.FeedUrl);
+                var items = ParseFeed(feed);
+                // Process items...
+            }
+            catch (HttpRequestException ex)
+            {
+                // Expected failure - log and schedule retry
+                _log.Warning("Feed {Url} unavailable: {Error}", msg.FeedUrl, ex.Message);
+                Context.System.Scheduler.ScheduleTellOnce(
+                    TimeSpan.FromMinutes(5),
+                    Self,
+                    msg,
+                    Self);
+            }
+            catch (XmlException ex)
+            {
+                // Invalid feed format - log and mark as bad
+                _log.Error("Feed {Url} has invalid format: {Error}", msg.FeedUrl, ex.Message);
+                Sender.Tell(new FeedPollResult.InvalidFormat(msg.FeedUrl));
+            }
+        });
+    }
+}
+```
+
+### When to Let Supervision Handle It
+
+**Let exceptions propagate (trigger supervision) when:**
+- You have **no idea** why the exception occurred
+- The actor's **state might be corrupt**
+- A **restart would help** (fresh state, reconnect resources)
+- It's a **programming error** (NullReferenceException, InvalidOperationException from bad logic)
+
+```csharp
+public class OrderActor : ReceiveActor
+{
+    private OrderState _state;
+
+    public OrderActor()
+    {
+        Receive<ProcessPayment>(msg =>
+        {
+            // If this throws, we have no idea why - let supervision restart us
+            // A restart will reload state from persistence and might fix the issue
+            var result = _state.ApplyPayment(msg.Amount);
+            Persist(new PaymentApplied(msg.Amount), evt =>
+            {
+                _state = _state.With(evt);
+            });
+        });
+    }
+}
+```
+
+### Anti-Pattern: Swallowing Unknown Exceptions
+
+```csharp
+// BAD: Swallowing exceptions hides problems
+public class BadActor : ReceiveActor
+{
+    public BadActor()
+    {
+        ReceiveAsync<DoWork>(async msg =>
+        {
+            try
+            {
+                await ProcessWork(msg);
+            }
+            catch (Exception ex)
+            {
+                // This hides all errors - you'll never know something is broken
+                _log.Error(ex, "Error processing work");
+                // Actor continues with potentially corrupt state
+            }
+        });
+    }
+}
+
+// GOOD: Handle known exceptions, let unknown ones propagate
+public class GoodActor : ReceiveActor
+{
+    public GoodActor()
+    {
+        ReceiveAsync<DoWork>(async msg =>
+        {
+            try
+            {
+                await ProcessWork(msg);
+            }
+            catch (HttpRequestException ex)
+            {
+                // Known, expected failure - handle gracefully
+                _log.Warning("HTTP request failed: {Error}", ex.Message);
+                Sender.Tell(new WorkResult.TransientFailure());
+            }
+            // Unknown exceptions propagate to supervision
+        });
+    }
+}
+```
+
+---
+
+## 4. Props vs DependencyResolver
+
+### When to Use Plain Props
+
+**Use `Props.Create()` when:**
+- Actor doesn't need `IServiceProvider` or `IRequiredActor<T>`
+- All dependencies can be passed via constructor
+- Actor is simple and self-contained
+
+```csharp
+// Simple actor with no DI needs
+public static Props Props(PostId postId, IPostWriteStore store)
+    => Akka.Actor.Props.Create(() => new PostEngagementActor(postId, store));
+
+// Usage
+var actor = Context.ActorOf(PostEngagementActor.Props(postId, store), postId.ToString());
+```
+
+### When to Use DependencyResolver
+
+**Use `resolver.Props<T>()` when:**
+- Actor needs `IServiceProvider` to create scoped services
+- Actor uses `IRequiredActor<T>` to get references to other actors
+- Actor has many dependencies that are already in DI container
+
+```csharp
+// Actor that needs scoped database connections
+public class OrderProcessorActor : ReceiveActor
+{
+    public OrderProcessorActor(IServiceProvider serviceProvider)
+    {
+        ReceiveAsync<ProcessOrder>(async msg =>
+        {
+            // Create a scope for this operation
+            using var scope = serviceProvider.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<OrderDbContext>();
+            // Process order...
+        });
+    }
+}
+
+// Registration with DI
+builder.WithActors((system, registry, resolver) =>
+{
+    var actor = system.ActorOf(resolver.Props<OrderProcessorActor>(), "order-processor");
+    registry.Register<OrderProcessorActor>(actor);
+});
+```
+
+### Remote Deployment Considerations
+
+**You almost never need remote deployment.** Remote deployment means deploying an actor to run on a different node than the one creating it.
+
+If you're not doing remote deployment (and you probably aren't):
+- `Props.Create(() => new Actor(...))` with closures is fine
+- The "serialization issue" warning doesn't apply
+
+**When you would use remote deployment:**
+- Distributing compute-intensive work to specific nodes
+- Running actors on nodes with specific hardware (GPU, etc.)
+
+For most applications, use **cluster sharding** instead of remote deployment - it handles distribution automatically.
+
+---
+
+## 5. Work Distribution Patterns
+
+### Problem: Thundering Herd
+
+When you have many background jobs (RSS feeds, email sending, etc.), don't process them all at once:
+
+```csharp
+// BAD: Polls all feeds simultaneously on startup
+public class BadRssCoordinator : ReceiveActor
+{
+    public BadRssCoordinator(IRssFeedRepository repo)
+    {
+        ReceiveAsync<StartPolling>(async _ =>
+        {
+            var feeds = await repo.GetAllFeedsAsync();
+            foreach (var feed in feeds) // 2000 feeds = 2000 simultaneous HTTP requests
+            {
+                Context.ActorOf(RssFeedPollerActor.Props(feed.Url));
+            }
+        });
+    }
+}
+```
+
+### Pattern 1: Database-Driven Work Queue
+
+Use the database as a work queue with `FOR UPDATE SKIP LOCKED`:
+
+```csharp
+public class RssPollerWorker : ReceiveActor
+{
+    public RssPollerWorker(IRssFeedRepository repo)
+    {
+        ReceiveAsync<PollBatch>(async _ =>
+        {
+            // Each worker claims a batch - naturally distributes across nodes
+            var feeds = await repo.ClaimFeedsForPollingAsync(
+                batchSize: 10,
+                staleAfter: TimeSpan.FromMinutes(10));
+
+            foreach (var feed in feeds)
+            {
+                try
+                {
+                    await PollFeed(feed);
+                    await repo.MarkPolledAsync(feed.Id, success: true);
+                }
+                catch (Exception ex)
+                {
+                    await repo.MarkPolledAsync(feed.Id, success: false, error: ex.Message);
+                }
+            }
+
+            // Schedule next batch
+            Context.System.Scheduler.ScheduleTellOnce(
+                TimeSpan.FromSeconds(5),
+                Self,
+                PollBatch.Instance,
+                Self);
+        });
+    }
+}
+```
+
+```sql
+-- ClaimFeedsForPollingAsync implementation
+UPDATE rss_feeds
+SET status = 'processing',
+    processing_started_at = NOW()
+WHERE id IN (
+    SELECT id FROM rss_feeds
+    WHERE status = 'pending'
+      AND (next_poll_at IS NULL OR next_poll_at <= NOW())
+    ORDER BY next_poll_at NULLS FIRST
+    LIMIT @batchSize
+    FOR UPDATE SKIP LOCKED
+)
+RETURNING *;
+```
+
+**Benefits:**
+- Naturally distributes work across multiple server nodes
+- No coordination needed - database handles locking
+- Easy to monitor (query the table)
+- Survives server restarts
+
+### Pattern 2: Akka.Streams for Rate Limiting
+
+Use Akka.Streams to throttle processing within a single node:
+
+```csharp
+public class ThrottledRssProcessor : ReceiveActor
+{
+    public ThrottledRssProcessor(IRssFeedRepository repo)
+    {
+        var materializer = Context.System.Materializer();
+
+        ReceiveAsync<StartProcessing>(async _ =>
+        {
+            await Source.From(await repo.GetPendingFeedsAsync())
+                .Throttle(10, TimeSpan.FromSeconds(1)) // Max 10 per second
+                .SelectAsync(4, async feed => // Max 4 concurrent
+                {
+                    await PollFeed(feed);
+                    return feed;
+                })
+                .RunWith(Sink.Ignore<RssFeed>(), materializer);
+        });
+    }
+}
+```
+
+### Pattern 3: Durable Queue (Email Outbox Pattern)
+
+For work that must be reliably processed, use a database-backed outbox:
+
+```csharp
+// Enqueue work transactionally with business operation
+public async Task CreatePostAsync(Post post)
+{
+    await using var transaction = await _db.BeginTransactionAsync();
+
+    await _postStore.CreateAsync(post);
+
+    // Enqueue notification emails in same transaction
+    foreach (var follower in await _followStore.GetFollowersAsync(post.AuthorId))
+    {
+        await _emailOutbox.EnqueueAsync(new EmailJob
+        {
+            To = follower.Email,
+            Template = "new-post",
+            Data = JsonSerializer.Serialize(new { PostId = post.Id })
+        });
+    }
+
+    await transaction.CommitAsync();
+}
+
+// Worker processes outbox
+public class EmailOutboxWorker : ReceiveActor
+{
+    public EmailOutboxWorker(IEmailOutboxStore outbox, IEmailSender sender)
+    {
+        ReceiveAsync<ProcessBatch>(async _ =>
+        {
+            var batch = await outbox.ClaimBatchAsync(10);
+            foreach (var job in batch)
+            {
+                try
+                {
+                    await sender.SendAsync(job);
+                    await outbox.MarkSentAsync(job.Id);
+                }
+                catch (Exception ex)
+                {
+                    await outbox.MarkFailedAsync(job.Id, ex.Message);
+                }
+            }
+        });
+    }
+}
+```
+
+---
+
+## 6. Common Mistakes Summary
+
+| Mistake | Why It's Wrong | Fix |
+|---------|----------------|-----|
+| Using EventStream for cross-node pub/sub | EventStream is local only | Use DistributedPubSub |
+| Defining supervision to "protect" an actor | Supervision protects children | Understand the hierarchy |
+| Catching all exceptions | Hides bugs, corrupts state | Only catch expected errors |
+| Always using DependencyResolver | Adds unnecessary complexity | Use plain Props when possible |
+| Processing all background jobs at once | Thundering herd, resource exhaustion | Use database queue + rate limiting |
+| Throwing exceptions for expected failures | Triggers unnecessary restarts | Return result types, use messaging |
+
+---
+
+## 7. Quick Reference
+
+### Communication Pattern Decision Tree
+
+```
+Need to communicate between actors?
+├── Same process only? → EventStream is fine
+├── Across cluster nodes?
+│   ├── Point-to-point? → Use ActorSelection or known IActorRef
+│   └── Pub/sub? → Use DistributedPubSub
+└── Fire-and-forget to external system? → Consider outbox pattern
+```
+
+### Error Handling Decision Tree
+
+```
+Exception occurred in actor?
+├── Expected failure (HTTP timeout, invalid input)?
+│   └── Try-catch, handle gracefully, continue
+├── State might be corrupt?
+│   └── Let supervision restart
+├── Unknown cause?
+│   └── Let supervision restart
+└── Programming error (null ref, bad logic)?
+    └── Let supervision restart, fix the bug
+```
+
+### Props Decision Tree
+
+```
+Creating actor Props?
+├── Actor needs IServiceProvider?
+│   └── Use resolver.Props<T>()
+├── Actor needs IRequiredActor<T>?
+│   └── Use resolver.Props<T>()
+├── Simple actor with constructor params?
+│   └── Use Props.Create(() => new Actor(...))
+└── Remote deployment needed?
+    └── Probably not - use cluster sharding instead
+```


### PR DESCRIPTION
## Summary

Add two new Claude Code skills for Akka.NET development:

### akka-hosting-actor-patterns.md
- GenericChildPerEntityParent for local testing
- Message extractors (IMessageExtractor)  
- Cluster sharding abstraction with AkkaExecutionMode
- Akka.Reminders integration
- ITimeProvider for testability

### akka-net-best-practices.md
Critical clarifications and patterns:
- **EventStream is LOCAL ONLY** - must use DistributedPubSub for multi-node communication
- **Supervision strategies supervise CHILDREN, not the actor itself**
- Default supervision already has rate limiting (10 restarts/second = permanent stop)
- When to use try-catch (expected failures) vs letting supervision handle (unknown errors, corrupt state)
- Props.Create vs DependencyResolver decision tree
- Work distribution patterns:
  - Database-driven queue with `FOR UPDATE SKIP LOCKED`
  - Akka.Streams for rate limiting
  - Outbox pattern for reliable processing

## Test plan
- [ ] Run sync.sh to deploy to ~/.claude/skills/
- [ ] Verify skills appear in Claude Code