### PR TITLE
Fix plugin manifest agents format

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -34,11 +34,5 @@
     "./skills/testing/crap-analysis",
     "./skills/testing/snapshot-testing"
   ],
-  "agents": [
-    "./agents/akka-net-specialist",
-    "./agents/docfx-specialist",
-    "./agents/dotnet-benchmark-designer",
-    "./agents/dotnet-concurrency-specialist",
-    "./agents/dotnet-performance-analyst"
-  ]
+  "agents": "./agents/"
 }

--- a/README.md
+++ b/README.md
@@ -4,16 +4,18 @@ A comprehensive Claude Code plugin with **25 skills** and **5 specialized agents
 
 ## Installation
 
-```bash
-# Add the marketplace (one-time)
+Add the marketplace (one-time):
+```
 /plugin marketplace add Aaronontheweb/dotnet-skills
+```
 
-# Install the plugin
+Install the plugin:
+```
 /plugin install dotnet-skills
 ```
 
 To update:
-```bash
+```
 /plugin marketplace update
 ```
 
@@ -138,11 +140,11 @@ dotnet-skills/
 ├── .claude-plugin/
 │   └── plugin.json         # Plugin manifest
 ├── agents/                 # 5 specialized agents
-│   ├── akka-net-specialist/
-│   ├── docfx-specialist/
-│   ├── dotnet-benchmark-designer/
-│   ├── dotnet-concurrency-specialist/
-│   └── dotnet-performance-analyst/
+│   ├── akka-net-specialist.md
+│   ├── docfx-specialist.md
+│   ├── dotnet-benchmark-designer.md
+│   ├── dotnet-concurrency-specialist.md
+│   └── dotnet-performance-analyst.md
 └── skills/                 # 25 comprehensive skills
     ├── akka/               # Akka.NET (5 skills)
     ├── aspire/             # .NET Aspire (2 skills)


### PR DESCRIPTION
## Summary
- Change `agents` field from array to directory path per Claude Code plugin spec
- Update validation script to handle both directory and array formats
- Fix bash arithmetic exit code issues in validation script
- Make README installation commands copy-pasteable
- Fix agents file extensions in repo structure documentation

## Test plan
- [x] Run `./scripts/validate-marketplace.sh` - passes
- [x] Reinstall plugin with `/plugin install dotnet-skills`