### PR TITLE
Remove unsupported color field from agents

### DIFF
--- a/agents/akka-net-specialist.md
+++ b/agents/akka-net-specialist.md
@@ -2,7 +2,6 @@
 name: akka-net-specialist
 description: Expert in Akka.NET architecture, actor systems, and distributed computing patterns. Specializes in analyzing actor lifecycle issues, message passing problems, cluster coordination, persistence, and stream processing. Use for Akka.NET-specific debugging, architecture decisions, and understanding actor system behavior.
 model: opus
-color: purple
 ---
 
 You are an Akka.NET architecture specialist with deep expertise in the actor model and distributed systems. You understand the intricacies of concurrent, fault-tolerant systems built with Akka.NET.

--- a/agents/docfx-specialist.md
+++ b/agents/docfx-specialist.md
@@ -2,7 +2,6 @@
 name: docfx-specialist
 description: Expert in DocFX documentation system, markdown formatting, and Akka.NET documentation standards. Handles DocFX-specific syntax, API references, build validation, and compliance with project documentation guidelines. Integrates markdownlint and DocFX compilation checks.
 model: sonnet
-color: blue
 ---
 
 You are a DocFX documentation specialist with expertise in the DocFX static site generator and Akka.NET documentation standards.

--- a/agents/dotnet-benchmark-designer.md
+++ b/agents/dotnet-benchmark-designer.md
@@ -2,7 +2,6 @@
 name: dotnet-benchmark-designer
 description: Expert in designing effective .NET performance benchmarks and instrumentation. Specializes in BenchmarkDotNet patterns, custom benchmark design, profiling setup, and choosing the right measurement approach for different scenarios. Knows when BenchmarkDotNet isn't suitable and custom benchmarks are needed.
 model: sonnet
-color: orange
 ---
 
 You are a .NET performance benchmark design specialist with expertise in creating accurate, reliable, and meaningful performance tests.

--- a/agents/dotnet-concurrency-specialist.md
+++ b/agents/dotnet-concurrency-specialist.md
@@ -2,7 +2,6 @@
 name: dotnet-concurrency-specialist
 description: Expert in .NET concurrency, threading, and race condition analysis. Specializes in Task/async patterns, thread safety, synchronization primitives, and identifying timing-dependent bugs in multithreaded .NET applications. Use for analyzing racy unit tests, deadlocks, and concurrent code issues.
 model: opus
-color: red
 ---
 
 You are a .NET concurrency specialist with deep expertise in multithreading, async programming, and race condition diagnosis.

--- a/agents/dotnet-performance-analyst.md
+++ b/agents/dotnet-performance-analyst.md
@@ -2,7 +2,6 @@
 name: dotnet-performance-analyst
 description: Expert in analyzing .NET application performance data, profiling results, and benchmark comparisons. Specializes in JetBrains profiler analysis, BenchmarkDotNet result interpretation, baseline comparisons, regression detection, and performance bottleneck identification.
 model: sonnet
-color: green
 ---
 
 You are a .NET performance analysis specialist with expertise in interpreting profiling data, benchmark results, and identifying performance bottlenecks.


### PR DESCRIPTION
## Summary
- Remove `color` field from all agent files - not a valid frontmatter option for plugins
- Fixes "agents: Invalid input" validation error during plugin installation

## Test plan
- [x] Validation script passes
- [ ] Plugin installs successfully with `/plugin install dotnet-skills`