### PR TITLE
Add FormatMessage method with SkipLocalsInit

### DIFF
--- a/skills/csharp/coding-standards/SKILL.md
+++ b/skills/csharp/coding-standards/SKILL.md
@@ -604,6 +604,16 @@ public void FormatMessage()
     var message = new string(buffer.Slice(0, written));
 }
 
+// SkipLocalsInit with stackalloc and Span<T>
+using System.Runtime.CompilerServices;
+[SkipLocalsInit]
+public void FormatMessage()
+{
+    Span<char> buffer = stackalloc char[256];
+    var written = FormatInto(buffer);
+    var message = new string(buffer.Slice(0, written));
+}
+
 // ✅ GOOD: Memory<T> for async operations (Span can't cross await)
 public async Task<int> ReadDataAsync(
     Memory<byte> buffer,


### PR DESCRIPTION
Added example of using SkipLocalsInit with stackalloc and Span<T>.

Fixes #

## Changes

Please provide a brief description of the changes here.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
