### PR TITLE
Add documentation context for SkipLocalsInit

### DIFF
--- a/skills/csharp/coding-standards/SKILL.md
+++ b/skills/csharp/coding-standards/SKILL.md
@@ -604,7 +604,14 @@ public void FormatMessage()
     var message = new string(buffer.Slice(0, written));
 }
 
-// SkipLocalsInit with stackalloc and Span<T>
+// SkipLocalsInit with stackalloc - skips zero-initialization for performance
+// By default, .NET zero-initializes all locals (.locals init flag). This can have
+// measurable overhead with stackalloc. Use [SkipLocalsInit] when:
+//   - You write to the buffer before reading (like FormatInto below)
+//   - Profiling shows zero-init as a bottleneck
+// ⚠️ WARNING: Reading before writing returns garbage data (see docs example)
+// Requires: <AllowUnsafeBlocks>true</AllowUnsafeBlocks> in .csproj
+// See: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/general#skiplocalsinit-attribute
 using System.Runtime.CompilerServices;
 [SkipLocalsInit]
 public void FormatMessage()


### PR DESCRIPTION
## Summary

Adds explanatory context to the `[SkipLocalsInit]` example from #16:

- Explains what the attribute does (skips `.locals init` zero-initialization)
- When to use it (write-before-read scenarios, profiling shows benefit)
- Warning about reading uninitialized memory
- Project requirement (`AllowUnsafeBlocks`)
- Link to official Microsoft documentation

## Changes

Enhanced the code comments in the `SkipLocalsInit` example to help developers understand the tradeoffs before using this optimization.

## References

- Microsoft Docs: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/general#skiplocalsinit-attribute
- Follow-up to #16