### PR TITLE
Make index regeneration an explicit step in skill/agent workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,22 +55,20 @@ color: purple  # optional
 1. Create a folder under the appropriate category: `skills/<category>/<skill-name>/SKILL.md`
 2. Add the skill path to `.claude-plugin/plugin.json` in the `skills` array
 3. Run `./scripts/validate-marketplace.sh` to verify
-4. Commit both changes together
+4. Run `./scripts/generate-skill-index-snippets.sh --update-readme` to regenerate the compressed index
+5. Commit all changes together (SKILL.md, plugin.json, and README.md)
 
-After adding/removing skills, update the downstream snippet/router indexes:
-- See `skills/meta/skills-index-snippets/SKILL.md`
-- Regenerate the compressed index with `./scripts/generate-skill-index-snippets.sh`
+### Creating a New Skill Category
+
+When adding a skill to a **new** top-level folder (e.g., `skills/playwright/`), you must also update `scripts/generate-skill-index-snippets.sh` to handle the new category in its `case` statement. Otherwise the skill will be silently ignored when generating the index.
 
 ## Adding New Agents
 
 1. Create the agent file: `agents/<agent-name>.md`
 2. Add the agent path to `.claude-plugin/plugin.json` in the `agents` array
 3. Run `./scripts/validate-marketplace.sh` to verify
-4. Commit both changes together
-
-After adding/removing agents, update the downstream snippet/router indexes:
-- See `skills/meta/skills-index-snippets/SKILL.md`
-- Regenerate the compressed index with `./scripts/generate-skill-index-snippets.sh`
+4. Run `./scripts/generate-skill-index-snippets.sh --update-readme` to regenerate the compressed index
+5. Commit all changes together (agent .md, plugin.json, and README.md)
 
 ## Marketplace Publishing
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Run `./scripts/generate-skill-index-snippets.sh --update-readme` to refresh the 
 |aspnetcore-web:{aspire-integration-testing,aspire-service-defaults,transactional-emails}
 |data:{efcore-patterns,database-performance}
 |di-config:{microsoft-extensions-configuration,dependency-injection-patterns}
-|testing:{testcontainers-integration-tests,playwright-blazor-testing,snapshot-testing}
+|testing:{testcontainers-integration-tests,playwright-blazor-testing,snapshot-testing,playwright-ci-caching}
 |dotnet:{dotnet-project-structure,dotnet-local-tools,package-management,serialization}
 |quality-gates:{dotnet-slopwatch,crap-analysis}
 |meta:{marketplace-publishing,skills-index-snippets}

--- a/scripts/generate-skill-index-snippets.sh
+++ b/scripts/generate-skill-index-snippets.sh
@@ -46,7 +46,7 @@ while IFS= read -r skill_dir; do
     ./skills/data/*) data+=("$name") ;;
     ./skills/microsoft-extensions/*) di_config+=("$name") ;;
     ./skills/dotnet/slopwatch|./skills/testing/crap-analysis) quality_gates+=("$name") ;;
-    ./skills/testing/*) testing+=("$name") ;;
+    ./skills/testing/*|./skills/playwright/*) testing+=("$name") ;;
     ./skills/dotnet/*) dotnet+=("$name") ;;
     ./skills/meta/*) meta+=("$name") ;;
     *) ;; # ignore


### PR DESCRIPTION
## Summary

Updates CLAUDE.md to make regenerating the compressed index an explicit numbered step (step 4) rather than a follow-up note that's easy to miss.

## Before

```
1. Create skill/agent
2. Add to plugin.json
3. Run validate script
4. Commit

After adding, update the indexes...
```

## After

```
1. Create skill/agent
2. Add to plugin.json
3. Run validate script
4. Run generate-skill-index-snippets.sh --update-readme
5. Commit all changes together
```

This makes it harder to forget updating the README.md compressed index when adding new skills or agents.