### PR TITLE
Combine stackalloc with pooling

### DIFF
--- a/skills/csharp/coding-standards/SKILL.md
+++ b/skills/csharp/coding-standards/SKILL.md
@@ -665,6 +665,35 @@ public async Task ProcessLargeFileAsync(
     }
 }
 
+// Hybrid buffer pattern for transient UTF-8 work. See caveats of SkipLocalsInit in the corresponding section.
+
+[SkipLocalsInit]
+static short GenerateHashCode(string? key)
+{
+    if (key is null) return 0;
+
+    const int StackLimit = 256;
+
+    var enc = Encoding.UTF8;
+    var max = enc.GetMaxByteCount(key.Length);
+
+    byte[]? rented = null;
+    Span<byte> buf = max <= StackLimit
+        ? stackalloc byte[StackLimit]
+        : (rented = ArrayPool<byte>.Shared.Rent(max));
+
+    try
+    {
+        var written = enc.GetBytes(key.AsSpan(), buf);
+        ComputeHash(buf[..written], out var h1, out var h2);
+        return unchecked((short)(h1 ^ h2));
+    }
+    finally
+    {
+        if (rented is not null) ArrayPool<byte>.Shared.Return(rented);
+    }
+}
+
 // ✅ GOOD: Span-based parsing without substring allocations
 public static (string Protocol, string Host, int Port) ParseUrl(ReadOnlySpan<char> url)
 {


### PR DESCRIPTION
Fixes #

## Changes

This pattern is quite useful for unbounded inputs. It leverages stackalloc up to a certain size and then falls back to pooling above the threshold

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
