### PR TITLE
refactor: Split transactional-emails skill into 3 focused skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,7 +15,8 @@
     "./skills/akka/management",
     "./skills/aspire/integration-testing",
     "./skills/aspire/service-defaults",
-    "./skills/aspnetcore/transactional-emails",
+    "./skills/aspire/mailpit-integration",
+    "./skills/aspnetcore/mjml-email-templates",
     "./skills/csharp/coding-standards",
     "./skills/csharp/concurrency-patterns",
     "./skills/csharp/api-design",
@@ -33,6 +34,7 @@
     "./skills/testing/playwright-blazor",
     "./skills/testing/crap-analysis",
     "./skills/testing/snapshot-testing",
+    "./skills/testing/verify-email-snapshots",
     "./skills/playwright/ci-caching",
     "./skills/meta/marketplace-publishing",
     "./skills/meta/skills-index-snippets"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # .NET Skills for Claude Code
 
-A comprehensive Claude Code plugin with **27 skills** and **5 specialized agents** for professional .NET development. Battle-tested patterns from production systems covering C#, Akka.NET, Aspire, EF Core, testing, and performance optimization.
+A comprehensive Claude Code plugin with **30 skills** and **5 specialized agents** for professional .NET development. Battle-tested patterns from production systems covering C#, Akka.NET, Aspire, EF Core, testing, and performance optimization.
 
 ## Installation
 
@@ -130,10 +130,10 @@ Run `./scripts/generate-skill-index-snippets.sh --update-readme` to refresh the 
 |flow:{skim repo patterns -> consult dotnet-skills by name -> implement smallest-change -> note conflicts}
 |route:
 |csharp:{modern-csharp-coding-standards,csharp-concurrency-patterns,api-design,type-design-performance}
-|aspnetcore-web:{aspire-integration-testing,aspire-service-defaults,transactional-emails}
+|aspnetcore-web:{aspire-integration-testing,aspire-service-defaults,mailpit-integration,mjml-email-templates}
 |data:{efcore-patterns,database-performance}
 |di-config:{microsoft-extensions-configuration,dependency-injection-patterns}
-|testing:{testcontainers-integration-tests,playwright-blazor-testing,snapshot-testing,playwright-ci-caching}
+|testing:{testcontainers-integration-tests,playwright-blazor-testing,snapshot-testing,verify-email-snapshots,playwright-ci-caching}
 |dotnet:{dotnet-project-structure,dotnet-local-tools,package-management,serialization}
 |quality-gates:{dotnet-slopwatch,crap-analysis}
 |meta:{marketplace-publishing,skills-index-snippets}
@@ -197,14 +197,15 @@ Cloud-native application orchestration.
 | ----------------------- | ------------------------------------------------------------ |
 | **integration-testing** | DistributedApplicationTestingBuilder, Aspire.Hosting.Testing |
 | **service-defaults**    | OpenTelemetry, health checks, resilience, service discovery  |
+| **mailpit-integration** | Email testing with Mailpit container, SMTP config, test assertions |
 
 ### ASP.NET Core
 
 Web application patterns.
 
-| Skill                    | What You'll Learn                                      |
-| ------------------------ | ------------------------------------------------------ |
-| **transactional-emails** | MJML templates, variable substitution, Mailpit testing |
+| Skill                    | What You'll Learn                                         |
+| ------------------------ | --------------------------------------------------------- |
+| **mjml-email-templates** | MJML syntax, responsive layouts, template renderer, composer pattern |
 
 ### .NET Ecosystem
 
@@ -231,12 +232,13 @@ Dependency injection and configuration patterns.
 
 Comprehensive testing strategies.
 
-| Skill                 | What You'll Learn                                             |
-| --------------------- | ------------------------------------------------------------- |
-| **testcontainers**    | Docker-based integration tests, PostgreSQL, Redis, RabbitMQ   |
-| **playwright-blazor** | E2E testing for Blazor apps, page objects, async assertions   |
-| **crap-analysis**     | CRAP scores, coverage thresholds, ReportGenerator integration |
-| **snapshot-testing**  | Verify library, approval testing, API response validation     |
+| Skill                      | What You'll Learn                                             |
+| -------------------------- | ------------------------------------------------------------- |
+| **testcontainers**         | Docker-based integration tests, PostgreSQL, Redis, RabbitMQ   |
+| **playwright-blazor**      | E2E testing for Blazor apps, page objects, async assertions   |
+| **crap-analysis**          | CRAP scores, coverage thresholds, ReportGenerator integration |
+| **snapshot-testing**       | Verify library, approval testing, API response validation     |
+| **verify-email-snapshots** | Snapshot test email templates, catch rendering regressions    |
 
 ---
 
@@ -265,15 +267,15 @@ dotnet-skills/
 │   ├── dotnet-benchmark-designer.md
 │   ├── dotnet-concurrency-specialist.md
 │   └── dotnet-performance-analyst.md
-└── skills/                 # 25 comprehensive skills
+└── skills/                 # 30 comprehensive skills
     ├── akka/               # Akka.NET (5 skills)
-    ├── aspire/             # .NET Aspire (2 skills)
+    ├── aspire/             # .NET Aspire (3 skills)
     ├── aspnetcore/         # ASP.NET Core (1 skill)
     ├── csharp/             # C# language (4 skills)
     ├── data/               # Data access (2 skills)
     ├── dotnet/             # .NET ecosystem (5 skills)
     ├── microsoft-extensions/  # DI & config (2 skills)
-    └── testing/            # Testing (4 skills)
+    └── testing/            # Testing (5 skills)
 ```
 
 ---

--- a/skills/aspire/mailpit-integration/SKILL.md
+++ b/skills/aspire/mailpit-integration/SKILL.md
@@ -1,0 +1,458 @@
+---
+name: mailpit-integration
+description: Test email sending locally using Mailpit with .NET Aspire. Captures all outgoing emails without sending them. View rendered HTML, inspect headers, and verify delivery in integration tests.
+invocable: false
+---
+
+# Email Testing with Mailpit and .NET Aspire
+
+## When to Use This Skill
+
+Use this skill when:
+- Testing email delivery locally without sending real emails
+- Setting up email infrastructure in .NET Aspire
+- Writing integration tests that verify emails are sent
+- Debugging email rendering and headers
+
+**Related skills:**
+- `aspnetcore/mjml-email-templates` - MJML template authoring
+- `testing/verify-email-snapshots` - Snapshot test rendered HTML
+- `aspire/integration-testing` - General Aspire testing patterns
+
+---
+
+## What is Mailpit?
+
+[Mailpit](https://github.com/axllent/mailpit) is a lightweight email testing tool that:
+- Captures all SMTP traffic without delivering emails
+- Provides a web UI to view captured emails
+- Exposes an API for programmatic access
+- Supports HTML rendering, headers, and attachments
+
+Perfect for development and integration testing.
+
+---
+
+## Aspire AppHost Configuration
+
+Add Mailpit as a container in your AppHost:
+
+```csharp
+// AppHost/Program.cs
+var builder = DistributedApplication.CreateBuilder(args);
+
+// Add Mailpit for email testing
+var mailpit = builder.AddContainer("mailpit", "axllent/mailpit")
+    .WithHttpEndpoint(port: 8025, targetPort: 8025, name: "ui")
+    .WithEndpoint(port: 1025, targetPort: 1025, name: "smtp");
+
+// Reference in your API project
+var api = builder.AddProject<Projects.MyApp_Api>("api")
+    .WithReference(mailpit.GetEndpoint("smtp"))
+    .WithEnvironment("Smtp__Host", mailpit.GetEndpoint("smtp"));
+
+builder.Build().Run();
+```
+
+---
+
+## SMTP Configuration
+
+### appsettings.json
+
+```json
+{
+  "Smtp": {
+    "Host": "localhost",
+    "Port": 1025,
+    "EnableSsl": false,
+    "FromAddress": "noreply@myapp.com",
+    "FromName": "MyApp"
+  }
+}
+```
+
+### Configuration Class
+
+```csharp
+public class SmtpSettings
+{
+    public string Host { get; set; } = "localhost";
+    public int Port { get; set; } = 1025;
+    public bool EnableSsl { get; set; } = false;
+    public string FromAddress { get; set; } = "noreply@myapp.com";
+    public string FromName { get; set; } = "MyApp";
+
+    // Optional: For production SMTP
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+}
+```
+
+### Service Registration
+
+```csharp
+// In Program.cs or extension method
+services.Configure<SmtpSettings>(configuration.GetSection("Smtp"));
+
+services.AddSingleton<IEmailSender>(sp =>
+{
+    var settings = sp.GetRequiredService<IOptions<SmtpSettings>>().Value;
+    return new SmtpEmailSender(settings);
+});
+```
+
+---
+
+## Email Sender Implementation
+
+```csharp
+public interface IEmailSender
+{
+    Task SendEmailAsync(EmailMessage message, CancellationToken ct = default);
+}
+
+public sealed class SmtpEmailSender : IEmailSender
+{
+    private readonly SmtpSettings _settings;
+
+    public SmtpEmailSender(SmtpSettings settings)
+    {
+        _settings = settings;
+    }
+
+    public async Task SendEmailAsync(EmailMessage message, CancellationToken ct = default)
+    {
+        using var client = new SmtpClient();
+
+        await client.ConnectAsync(
+            _settings.Host,
+            _settings.Port,
+            _settings.EnableSsl ? SecureSocketOptions.StartTls : SecureSocketOptions.None,
+            ct);
+
+        if (!string.IsNullOrEmpty(_settings.Username))
+        {
+            await client.AuthenticateAsync(_settings.Username, _settings.Password, ct);
+        }
+
+        var mailMessage = new MimeMessage();
+        mailMessage.From.Add(new MailboxAddress(_settings.FromName, _settings.FromAddress));
+        mailMessage.To.Add(new MailboxAddress(message.ToName, message.To));
+        mailMessage.Subject = message.Subject;
+
+        var bodyBuilder = new BodyBuilder { HtmlBody = message.HtmlBody };
+        mailMessage.Body = bodyBuilder.ToMessageBody();
+
+        await client.SendAsync(mailMessage, ct);
+        await client.DisconnectAsync(true, ct);
+    }
+}
+```
+
+Requires `MailKit` package:
+
+```bash
+dotnet add package MailKit
+```
+
+---
+
+## Viewing Captured Emails
+
+### Web UI
+
+Navigate to `http://localhost:8025` to see:
+
+- **Inbox** - All captured emails
+- **HTML view** - Rendered email
+- **Source view** - Raw HTML/MJML output
+- **Headers** - Full email headers
+- **Attachments** - Any attached files
+
+### Aspire Dashboard
+
+The Mailpit UI endpoint appears in the Aspire dashboard under Resources.
+
+---
+
+## Integration Testing
+
+### Test Fixture with Aspire
+
+```csharp
+public class EmailIntegrationTests : IClassFixture<AspireFixture>
+{
+    private readonly HttpClient _client;
+    private readonly MailpitClient _mailpit;
+
+    public EmailIntegrationTests(AspireFixture fixture)
+    {
+        _client = fixture.CreateClient();
+        _mailpit = new MailpitClient(fixture.GetMailpitUrl());
+    }
+
+    [Fact]
+    public async Task SignupFlow_SendsWelcomeEmail()
+    {
+        // Arrange
+        await _mailpit.ClearMessagesAsync();
+
+        // Act - Trigger signup flow
+        var response = await _client.PostAsJsonAsync("/api/auth/signup", new
+        {
+            Email = "test@example.com",
+            Password = "SecurePassword123!"
+        });
+        response.EnsureSuccessStatusCode();
+
+        // Assert - Verify email was sent
+        var messages = await _mailpit.GetMessagesAsync();
+
+        var welcomeEmail = messages.Should().ContainSingle()
+            .Which;
+
+        welcomeEmail.To.Should().Contain("test@example.com");
+        welcomeEmail.Subject.Should().Contain("Welcome");
+        welcomeEmail.HtmlBody.Should().Contain("Thank you for signing up");
+    }
+}
+```
+
+### Mailpit API Client
+
+```csharp
+public class MailpitClient
+{
+    private readonly HttpClient _client;
+
+    public MailpitClient(string baseUrl)
+    {
+        _client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+    }
+
+    public async Task<List<MailpitMessage>> GetMessagesAsync()
+    {
+        var response = await _client.GetFromJsonAsync<MailpitResponse>("/api/v1/messages");
+        return response?.Messages ?? new List<MailpitMessage>();
+    }
+
+    public async Task ClearMessagesAsync()
+    {
+        await _client.DeleteAsync("/api/v1/messages");
+    }
+
+    public async Task<MailpitMessage?> WaitForMessageAsync(
+        Func<MailpitMessage, bool> predicate,
+        TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var messages = await GetMessagesAsync();
+            var match = messages.FirstOrDefault(predicate);
+
+            if (match != null)
+                return match;
+
+            await Task.Delay(100);
+        }
+
+        return null;
+    }
+}
+
+public class MailpitResponse
+{
+    public List<MailpitMessage> Messages { get; set; } = new();
+}
+
+public class MailpitMessage
+{
+    public string Id { get; set; } = "";
+    public List<string> To { get; set; } = new();
+    public string Subject { get; set; } = "";
+    public string HtmlBody { get; set; } = "";
+}
+```
+
+---
+
+## Aspire Test Fixture
+
+```csharp
+public class AspireFixture : IAsyncLifetime
+{
+    private DistributedApplication? _app;
+    private string _mailpitUrl = "";
+
+    public async Task InitializeAsync()
+    {
+        var appHost = await DistributedApplicationTestingBuilder
+            .CreateAsync<Projects.MyApp_AppHost>();
+
+        // Disable persistence for clean tests
+        appHost.Configuration["MyApp:UseVolumes"] = "false";
+
+        _app = await appHost.BuildAsync();
+        await _app.StartAsync();
+
+        // Get Mailpit URL from Aspire
+        var mailpit = _app.GetContainerResource("mailpit");
+        _mailpitUrl = await mailpit.GetEndpointAsync("ui");
+    }
+
+    public HttpClient CreateClient()
+    {
+        var api = _app!.GetProjectResource("api");
+        return api.CreateHttpClient();
+    }
+
+    public string GetMailpitUrl() => _mailpitUrl;
+
+    public async Task DisposeAsync()
+    {
+        if (_app != null)
+            await _app.DisposeAsync();
+    }
+}
+```
+
+---
+
+## Common Test Patterns
+
+### Wait for Async Email
+
+Some emails are sent asynchronously. Wait for them:
+
+```csharp
+[Fact]
+public async Task AsyncWorkflow_EventuallySendsEmail()
+{
+    await _mailpit.ClearMessagesAsync();
+
+    // Trigger async workflow
+    await _client.PostAsync("/api/workflows/start", null);
+
+    // Wait for email (with timeout)
+    var email = await _mailpit.WaitForMessageAsync(
+        m => m.Subject.Contains("Workflow Complete"),
+        timeout: TimeSpan.FromSeconds(10));
+
+    email.Should().NotBeNull();
+}
+```
+
+### Verify Multiple Emails
+
+```csharp
+[Fact]
+public async Task BulkOperation_SendsMultipleEmails()
+{
+    await _mailpit.ClearMessagesAsync();
+
+    await _client.PostAsJsonAsync("/api/invitations/bulk", new
+    {
+        Emails = new[] { "a@test.com", "b@test.com", "c@test.com" }
+    });
+
+    var messages = await _mailpit.WaitForMessagesAsync(
+        expectedCount: 3,
+        timeout: TimeSpan.FromSeconds(10));
+
+    messages.Should().HaveCount(3);
+    messages.Select(m => m.To.First())
+        .Should().BeEquivalentTo("a@test.com", "b@test.com", "c@test.com");
+}
+```
+
+### Verify Email Content
+
+```csharp
+[Fact]
+public async Task PasswordReset_ContainsValidResetLink()
+{
+    await _mailpit.ClearMessagesAsync();
+
+    await _client.PostAsJsonAsync("/api/auth/forgot-password", new
+    {
+        Email = "user@test.com"
+    });
+
+    var email = await _mailpit.WaitForMessageAsync(
+        m => m.Subject.Contains("Password Reset"),
+        timeout: TimeSpan.FromSeconds(5));
+
+    // Extract reset link from HTML
+    var resetLink = Regex.Match(email!.HtmlBody, @"href=""([^""]+/reset/[^""]+)""")
+        .Groups[1].Value;
+
+    resetLink.Should().StartWith("https://myapp.com/reset/");
+
+    // Verify the link works
+    var resetResponse = await _client.GetAsync(resetLink);
+    resetResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+}
+```
+
+---
+
+## Production vs Development
+
+```csharp
+services.AddSingleton<IEmailSender>(sp =>
+{
+    var settings = sp.GetRequiredService<IOptions<SmtpSettings>>().Value;
+    var env = sp.GetRequiredService<IHostEnvironment>();
+
+    if (env.IsDevelopment())
+    {
+        // Mailpit - no auth, no SSL
+        return new SmtpEmailSender(settings);
+    }
+    else
+    {
+        // Production SMTP (SendGrid, Postmark, etc.)
+        return new SmtpEmailSender(settings with
+        {
+            EnableSsl = true
+        });
+    }
+});
+```
+
+---
+
+## Troubleshooting
+
+### Emails Not Appearing
+
+1. Check Mailpit container is running in Aspire dashboard
+2. Verify SMTP host/port configuration
+3. Check for exceptions in application logs
+
+### Connection Refused
+
+```bash
+# Verify Mailpit is listening
+curl http://localhost:8025/api/v1/messages
+```
+
+### Aspire Endpoint Not Resolving
+
+```csharp
+// Ensure endpoint reference is correct
+.WithEnvironment("Smtp__Host", mailpit.GetEndpoint("smtp").Property(EndpointProperty.Host))
+.WithEnvironment("Smtp__Port", mailpit.GetEndpoint("smtp").Property(EndpointProperty.Port))
+```
+
+---
+
+## Resources
+
+- **Mailpit**: https://github.com/axllent/mailpit
+- **Mailpit API**: https://mailpit.axllent.org/docs/api-v1/
+- **MailKit**: https://github.com/jstedfast/MailKit
+- **Aspire Containers**: https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/container-resources

--- a/skills/testing/verify-email-snapshots/SKILL.md
+++ b/skills/testing/verify-email-snapshots/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: verify-email-snapshots
+description: Snapshot test email templates using Verify to catch regressions. Validates rendered HTML output matches approved baseline. Works with MJML templates and any email renderer.
+invocable: false
+---
+
+# Snapshot Testing Email Templates with Verify
+
+## When to Use This Skill
+
+Use this skill when:
+- Testing email template rendering for regressions
+- Validating MJML templates compile to expected HTML
+- Reviewing email changes in code review (diffs are visual)
+- Ensuring variable substitution works correctly
+
+**Related skills:**
+- `aspnetcore/mjml-email-templates` - MJML template authoring
+- `aspire/mailpit-integration` - Test email delivery locally
+- `testing/snapshot-testing` - General Verify patterns
+
+---
+
+## Why Snapshot Test Emails?
+
+Email templates are:
+1. **Visual** - Small changes can break rendering across clients
+2. **Hard to unit test** - Output is complex HTML, not simple values
+3. **Prone to regression** - Template changes can have unintended effects
+
+Snapshot testing captures the rendered HTML and fails when it changes unexpectedly.
+
+---
+
+## Installation
+
+```bash
+dotnet add package Verify.Xunit  # or Verify.NUnit, Verify.MSTest
+```
+
+---
+
+## Basic Email Snapshot Test
+
+```csharp
+[Fact]
+public async Task UserSignupInvitation_RendersCorrectly()
+{
+    // Arrange
+    var renderer = _services.GetRequiredService<IMjmlTemplateRenderer>();
+
+    var variables = new Dictionary<string, string>
+    {
+        { "PreviewText", "You've been invited to join Acme Corp" },
+        { "OrganizationName", "Acme Corporation" },
+        { "InviteeName", "John Doe" },
+        { "InviterName", "Jane Admin" },
+        { "InvitationLink", "https://example.com/invite/abc123" },
+        { "ExpirationDate", "December 31, 2025" }
+    };
+
+    // Act
+    var html = await renderer.RenderTemplateAsync(
+        "UserInvitations/UserSignupInvitation",
+        variables);
+
+    // Assert
+    await Verify(html, extension: "html");
+}
+```
+
+This creates `UserSignupInvitation_RendersCorrectly.verified.html` on first run.
+
+---
+
+## Reviewing Email Changes
+
+When a template changes, the test fails with a diff. Review options:
+
+### 1. Visual Diff Tool
+
+```bash
+# Configure diff tool (one-time)
+dotnet tool install -g verify.tool
+verify accept  # Accept all pending changes
+verify review  # Open diff tool
+```
+
+### 2. Browser Preview
+
+Open the `.received.html` file in a browser to see the actual rendering.
+
+### 3. IDE Integration
+
+Most IDEs show inline diffs for `.verified.html` vs `.received.html` files.
+
+---
+
+## Test Each Template Variant
+
+Create tests for each email template to catch regressions:
+
+```csharp
+public class EmailTemplateSnapshotTests : IClassFixture<EmailTestFixture>
+{
+    private readonly IMjmlTemplateRenderer _renderer;
+
+    public EmailTemplateSnapshotTests(EmailTestFixture fixture)
+    {
+        _renderer = fixture.Services.GetRequiredService<IMjmlTemplateRenderer>();
+    }
+
+    [Fact]
+    public async Task WelcomeEmail_NewUser() =>
+        await VerifyTemplate("Welcome/NewUser", new Dictionary<string, string>
+        {
+            { "UserName", "John Doe" },
+            { "LoginUrl", "https://example.com/login" }
+        });
+
+    [Fact]
+    public async Task WelcomeEmail_InvitedUser() =>
+        await VerifyTemplate("Welcome/InvitedUser", new Dictionary<string, string>
+        {
+            { "UserName", "John Doe" },
+            { "InviterName", "Jane Admin" },
+            { "OrganizationName", "Acme Corp" }
+        });
+
+    [Fact]
+    public async Task PasswordReset() =>
+        await VerifyTemplate("PasswordReset/PasswordReset", new Dictionary<string, string>
+        {
+            { "UserName", "John Doe" },
+            { "ResetLink", "https://example.com/reset/abc123" },
+            { "ExpirationMinutes", "30" }
+        });
+
+    [Fact]
+    public async Task PaymentReceipt() =>
+        await VerifyTemplate("Billing/PaymentReceipt", new Dictionary<string, string>
+        {
+            { "UserName", "John Doe" },
+            { "Amount", "$10.00" },
+            { "InvoiceNumber", "INV-2025-001" },
+            { "Date", "January 15, 2025" }
+        });
+
+    private async Task VerifyTemplate(
+        string templateName,
+        Dictionary<string, string> variables)
+    {
+        var html = await _renderer.RenderTemplateAsync(templateName, variables);
+        await Verify(html, extension: "html")
+            .UseMethodName(templateName.Replace("/", "_"));
+    }
+}
+```
+
+---
+
+## Scrubbing Dynamic Values
+
+Some values change between test runs. Scrub them:
+
+```csharp
+[Fact]
+public async Task EmailWithTimestamp_ScrubsDynamicValues()
+{
+    var html = await _renderer.RenderTemplateAsync("Welcome", variables);
+
+    await Verify(html, extension: "html")
+        .ScrubLinesContaining("Generated at:")
+        .ScrubInlineGuids();  // Scrubs GUIDs in URLs
+}
+```
+
+### Common Scrubbers
+
+```csharp
+// Scrub dates
+.ScrubLinesContaining("Date:")
+.AddScrubber(s => Regex.Replace(s, @"\d{4}-\d{2}-\d{2}", "SCRUBBED-DATE"))
+
+// Scrub URLs with tokens
+.AddScrubber(s => Regex.Replace(s, @"token=[a-zA-Z0-9]+", "token=SCRUBBED"))
+
+// Scrub GUIDs
+.ScrubInlineGuids()
+```
+
+---
+
+## Test Fixture for Email Tests
+
+```csharp
+public class EmailTestFixture : IAsyncLifetime
+{
+    public IServiceProvider Services { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SiteUrl"] = "https://example.com"
+            })
+            .Build());
+
+        services.AddSingleton<IMjmlTemplateRenderer, MjmlTemplateRenderer>();
+
+        Services = services.BuildServiceProvider();
+
+        await Task.CompletedTask;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}
+```
+
+---
+
+## Composer Snapshot Tests
+
+Test the full composer output including subject and metadata:
+
+```csharp
+[Fact]
+public async Task SignupInvitation_ComposesCorrectEmail()
+{
+    var composer = _services.GetRequiredService<IUserEmailComposer>();
+
+    var email = await composer.ComposeSignupInvitationAsync(
+        recipientEmail: new EmailAddress("john@example.com"),
+        recipientName: new PersonName("John Doe"),
+        inviterName: new PersonName("Jane Admin"),
+        organizationName: new OrganizationName("Acme Corp"),
+        invitationUrl: new AbsoluteUri("https://example.com/invite/abc123"),
+        expiresAt: new DateTimeOffset(2025, 12, 31, 0, 0, 0, TimeSpan.Zero));
+
+    // Verify the full email object (subject, to, body)
+    await Verify(new
+    {
+        email.To,
+        email.Subject,
+        HtmlBody = email.HtmlBody  // Will be stored as .html extension
+    });
+}
+```
+
+---
+
+## CI Integration
+
+### Fail on Missing Baseline
+
+In CI, fail if no `.verified.html` file exists (prevents accidental acceptance):
+
+```csharp
+// In test setup or ModuleInitializer
+VerifierSettings.ThrowOnMissingVerifiedFile();
+```
+
+### Git Configuration
+
+Add to `.gitattributes` to improve diff handling:
+
+```gitattributes
+*.verified.html linguist-language=HTML
+*.verified.html diff=html
+```
+
+---
+
+## Best Practices
+
+### DO
+
+```csharp
+// DO: Test each template variant
+[Fact] Task WelcomeEmail_NewUser_RendersCorrectly()
+[Fact] Task WelcomeEmail_InvitedUser_RendersCorrectly()
+
+// DO: Use descriptive test names
+[Fact] Task PaymentReceipt_WithRefund_ShowsRefundAmount()
+
+// DO: Scrub dynamic values consistently
+.ScrubLinesContaining("Generated at:")
+
+// DO: Review diffs carefully before accepting
+verify review
+```
+
+### DON'T
+
+```csharp
+// DON'T: Skip email testing
+// DON'T: Auto-accept changes without review
+verify accept --all  // Dangerous!
+
+// DON'T: Test only happy path
+// DON'T: Ignore snapshot test failures
+```
+
+---
+
+## Workflow
+
+1. **Create template** - Write MJML template
+2. **Write test** - Add snapshot test with sample variables
+3. **Run test** - First run creates `.verified.html`
+4. **Review** - Open in browser, verify rendering
+5. **Commit** - Include `.verified.html` in source control
+6. **Iterate** - Changes fail test, review diff, accept if correct
+
+---
+
+## Resources
+
+- **Verify**: https://github.com/VerifyTests/Verify
+- **Verify.Xunit**: https://github.com/VerifyTests/Verify#xunit
+- **Diff Tools**: https://github.com/VerifyTests/DiffEngine


### PR DESCRIPTION
## Summary

The original `transactional-emails` skill covered too many concerns, making it hard to discover when searching for specific topics like "mailpit" or "email testing".

Split into:
- `aspnetcore/mjml-email-templates` - MJML syntax and template authoring  
- `aspire/mailpit-integration` - Email testing with Aspire + Mailpit
- `testing/verify-email-snapshots` - Snapshot testing rendered HTML

## Motivation

When asked about "MailPit and Aspire email testing", the skill wasn't discoverable because:
1. The name `transactional-emails` doesn't mention MailPit or testing
2. The description mentioned it but the keywords weren't prominent

Now each skill is independently discoverable by its primary keyword.

## Changes

- Deleted `skills/aspnetcore/transactional-emails/`
- Created `skills/aspnetcore/mjml-email-templates/`
- Created `skills/aspire/mailpit-integration/`
- Created `skills/testing/verify-email-snapshots/`
- Updated `plugin.json` with new skill paths
- Updated README with new skill listings and counts (27 → 30 skills)
- Regenerated compressed index snippet