### PR TITLE
docs: Clarify installation instructions for multiple platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A comprehensive Claude Code plugin with **30 skills** and **5 specialized agents
 
 ## Installation
 
-This plugin uses the [Agent Skills open standard](https://github.com/anthropics/claude-code/blob/main/docs/plugins.md) and works with multiple AI coding assistants.
+This plugin works with multiple AI coding assistants that support skills/agents.
 
 ### Claude Code (CLI)
 


### PR DESCRIPTION
## Summary

- Add platform-specific installation sections (Claude Code CLI, GitHub Copilot, OpenCode)
- Clarify that `/plugin` commands run in Claude Code CLI, not VSCode extension
- Add where CLAUDE.md/AGENTS.md snippets go (project root)
- Update Repository Structure to show flat skills directory
- Update Contributing section for new flat structure

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm installation instructions are clear and actionable

Fixes #32