### PR TITLE
Release v1.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Comprehensive .NET development skills and agents for Claude Code - covering C#, F#, Akka.NET, Aspire, testing frameworks, and specialized tools",
   "author": {
     "name": "Aaron Stannard",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,39 @@
+# Release Notes
+
+## v1.2.0 (2026-02-05)
+
+### Breaking Changes
+
+- **Flattened skills directory structure** - Skills moved from `skills/category/skill-name/` to `skills/skill-name/` for GitHub Copilot plugin compatibility. Framework-specific skills use prefixes (`akka-*`, `aspire-*`, `csharp-*`, `microsoft-extensions-*`, `playwright-*`). General .NET skills have no prefix. ([#34](https://github.com/Aaronontheweb/dotnet-skills/pull/34))
+
+### Documentation Improvements
+
+- **Clarified installation instructions** - Added platform-specific installation sections for Claude Code CLI, GitHub Copilot, and OpenCode. Clarified that `/plugin` commands run in Claude Code CLI, not the VSCode extension. Updated repository structure documentation for the new flat skills layout. ([#35](https://github.com/Aaronontheweb/dotnet-skills/pull/35), fixes [#32](https://github.com/Aaronontheweb/dotnet-skills/issues/32))
+
+### Skill Enhancements
+
+- **Akka.NET best practices** - Added actor logging guidance using `ILoggingAdapter` from `Context.GetLogger()` instead of DI-injected `ILogger<T>`, including semantic logging support in v1.5.59+. Added guidance on managing async operations with `CancellationToken` - actor-scoped CancellationTokenSource in PostStop(), linked CTS for per-operation timeouts, and graceful shutdown handling. ([#36](https://github.com/Aaronontheweb/dotnet-skills/pull/36), fixes [#29](https://github.com/Aaronontheweb/dotnet-skills/issues/29), [#31](https://github.com/Aaronontheweb/dotnet-skills/issues/31))
+
+- **C# concurrency patterns** - Added guidance to prefer async local functions over `Task.Run(async () => ...)` and `ContinueWith()` for better stack traces, cleaner exception handling, and self-documenting code. Includes Akka.NET PipeTo example. ([#37](https://github.com/Aaronontheweb/dotnet-skills/pull/37), fixes [#30](https://github.com/Aaronontheweb/dotnet-skills/issues/30))
+
+- **CRAP analysis** - Added exclusions for Blazor generated code (`*.razor.g.cs`, `*.razor.css.g.cs`), EF Core migrations (`**/Migrations/**/*`), and `ExcludeFromCodeCoverageAttribute` to the coverage configuration guidance. ([#38](https://github.com/Aaronontheweb/dotnet-skills/pull/38), fixes [#6](https://github.com/Aaronontheweb/dotnet-skills/issues/6))
+
+### Issues Fixed
+
+- [#6](https://github.com/Aaronontheweb/dotnet-skills/issues/6) - Update crap-analysis skill to exclude generated code by default
+- [#29](https://github.com/Aaronontheweb/dotnet-skills/issues/29) - Add actor logging guidance to akka-net-best-practices skill
+- [#30](https://github.com/Aaronontheweb/dotnet-skills/issues/30) - Add guidance on async local functions vs Task.Run/ContinueWith
+- [#31](https://github.com/Aaronontheweb/dotnet-skills/issues/31) - Add guidance on cancellation tokens for long-running async operations in actors
+- [#32](https://github.com/Aaronontheweb/dotnet-skills/issues/32) - Please clarify the install instructions
+
+---
+
+## v1.1.0 (2026-02-01)
+
+Initial marketplace release with 30 skills and 5 agents covering the .NET ecosystem.
+
+See [GitHub Release v1.1.0](https://github.com/Aaronontheweb/dotnet-skills/releases/tag/v1.1.0) for full details.
+
+## v1.0.0 (2026-01-28)
+
+Initial release.


### PR DESCRIPTION
## Summary

Release v1.2.0 of dotnet-skills marketplace plugin.

### Changes in this release

**Breaking Changes:**
- Flattened skills directory structure for GitHub Copilot compatibility (#34)

**Documentation:**
- Clarified installation instructions for Claude Code CLI, GitHub Copilot, and OpenCode (#35)

**Skill Enhancements:**
- Added actor logging (ILoggingAdapter) and CancellationToken guidance to Akka best practices (#36)
- Added async local functions guidance to C# concurrency patterns (#37)
- Added Blazor and EF Core exclusions to crap-analysis skill (#38)

### Issues Fixed
- #6, #29, #30, #31, #32

### Release Checklist
- [x] Version bumped to 1.2.0 in plugin.json
- [x] RELEASE_NOTES.md created with changelog
- [ ] Merge this PR
- [ ] Create and push tag v1.2.0 (CI/CD will create release)