### PR TITLE
Update benchmark guidelines for baseline usage

### DIFF
--- a/agents/dotnet-benchmark-designer.md
+++ b/agents/dotnet-benchmark-designer.md
@@ -68,6 +68,7 @@ You are a .NET performance benchmark design specialist with expertise in creatin
 - Console output or logging during measurement
 - Synchronous blocking in async benchmarks
 - Ignoring GC impact on allocation-heavy operations
+- [Benchmark(Baseline = true)] on multiple benchmarks - use categories instead
 
 **Benchmark Code Generation:**
 When creating benchmarks, generate complete, runnable code including:


### PR DESCRIPTION
Clarify usage of [Benchmark(Baseline = true)] in benchmarks.

NEVER use [Benchmark(Baseline = true)] on multiple benchmarks. Only one benchmark per category group should have Baseline = true. To compare multiple implementations across different scenarios, use categories:

[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
[CategoriesColumn]

[BenchmarkCategory("SHA256 Small"), Benchmark(Baseline = true)]
public string Original_Implementation()
{
    // implementation
}

[BenchmarkCategory("SHA256 Small"), Benchmark]
public async ValueTask<string> New_Implementation()
{
    // implementation
}

## Changes

Please provide a brief description of the changes here.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
