### PR TITLE
Fix API design: optional params are binary incompatible

### DIFF
--- a/skills/csharp-api-design/SKILL.md
+++ b/skills/csharp-api-design/SKILL.md
@@ -57,11 +57,23 @@ The foundation of stable APIs: **never remove or modify, only extend**.
 ### Safe Changes (Any Release)
 
 ```csharp
-// ADD new overloads with default parameters
-public void Process(Order order, CancellationToken ct = default);
+// SAFE: Add NEW overload methods that delegate to existing methods
+// Existing method - do not modify its signature
+public void Process(Order order) { ... }
+// New overload - safe to add
+public void Process(Order order, CancellationToken ct)
+{
+    // implementation that handles cancellation
+}
 
-// ADD new optional parameters to existing methods
-public void Send(Message msg, Priority priority = Priority.Normal);
+// SAFE: Add NEW overloads for additional functionality
+// Existing method - do not modify
+public void Send(Message msg) { ... }
+// New overload - safe to add
+public void Send(Message msg, Priority priority)
+{
+    // implementation that handles priority
+}
 
 // ADD new types, interfaces, enums
 public interface IOrderValidator { }
@@ -88,6 +100,14 @@ public Order? GetOrder(string id);  // Was: public Order GetOrder()
 
 // CHANGE access modifiers
 internal class OrderProcessor { }  // Was: public
+
+// ADD optional parameters to EXISTING methods (binary incompatible!)
+// The compiled IL method signature changes - callers compiled against
+// the old signature will get MissingMethodException at runtime.
+// Optional parameter defaults are baked into the CALLER's assembly at compile time.
+public void Process(Order order, CancellationToken ct = default);  // Breaks binary compat!
+public void Send(Message msg, Priority priority = Priority.Normal);  // Breaks binary compat!
+// Correct approach: add a NEW overload method instead (see Safe Changes above)
 
 // ADD required parameters without defaults
 public void Process(Order order, ILogger logger);  // Breaks callers!


### PR DESCRIPTION
## Summary

Fixes #56

- Corrected the "Safe Changes" section: adding optional parameters to existing methods is **not** binary compatible — the IL method signature changes and callers compiled against the old signature get `MissingMethodException` at runtime
- Replaced incorrect examples with the correct pattern: add NEW overload methods that delegate to existing methods
- Moved the optional parameter anti-pattern to the "Unsafe Changes" section with an explanation of why it breaks (optional defaults are baked into the caller's assembly at compile time)

## Test plan

- [ ] Review that the Safe Changes section shows correct overload patterns
- [ ] Verify the Unsafe Changes section clearly explains the binary incompatibility
- [ ] Confirm the guidance matches real .NET binary compatibility behavior