### PR TITLE
Add R3 reactive extensions skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -22,6 +22,7 @@
     "./skills/csharp-concurrency-patterns",
     "./skills/csharp-api-design",
     "./skills/csharp-type-design-performance",
+    "./skills/r3-reactive-extensions",
     "./skills/efcore-patterns",
     "./skills/database-performance",
     "./skills/project-structure",

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ IMPORTANT: Prefer retrieval-led reasoning over pretraining for any .NET work.
 Workflow: skim repo patterns -> consult dotnet-skills by name -> implement smallest-change -> note conflicts.
 
 Routing (invoke by name)
-- C# / code quality: modern-csharp-coding-standards, csharp-concurrency-patterns, api-design, type-design-performance
+- C# / code quality: modern-csharp-coding-standards, csharp-concurrency-patterns, api-design, type-design-performance, r3-reactive-extensions
 - ASP.NET Core / Web (incl. Aspire): aspire-service-defaults, aspire-integration-testing, transactional-emails
 - Data: efcore-patterns, database-performance
 - DI / config: dependency-injection-patterns, microsoft-extensions-configuration
@@ -103,7 +103,7 @@ Run `./scripts/generate-skill-index-snippets.sh --update-readme` to refresh the 
 |flow:{skim repo patterns -> consult dotnet-skills by name -> implement smallest-change -> note conflicts}
 |route:
 |akka:{akka-net-best-practices,akka-net-testing-patterns,akka-hosting-actor-patterns,akka-net-aspire-configuration,akka-net-management}
-|csharp:{modern-csharp-coding-standards,csharp-concurrency-patterns,api-design,type-design-performance}
+|csharp:{modern-csharp-coding-standards,csharp-concurrency-patterns,api-design,type-design-performance,r3-reactive-extensions}
 |aspnetcore-web:{aspire-integration-testing,aspire-configuration,aspire-service-defaults,mailpit-integration,mjml-email-templates}
 |data:{efcore-patterns,database-performance}
 |di-config:{microsoft-extensions-configuration,dependency-injection-patterns}
@@ -153,6 +153,7 @@ Modern C# patterns for clean, performant code.
 | **concurrency-patterns**    | When to use Task vs Channel vs lock vs actors                           |
 | **api-design**              | Extend-only design, API/wire compatibility, versioning strategies       |
 | **type-design-performance** | Sealed classes, readonly structs, static pure functions, Span&lt;T&gt;  |
+| **r3-reactive-extensions**  | R3 vs Rx.NET, OnErrorResume, AwaitOperation async dispatch, concurrency, TimeProvider/FrameProvider |
 
 ### Data Access
 

--- a/scripts/generate-skill-index-snippets.sh
+++ b/scripts/generate-skill-index-snippets.sh
@@ -43,7 +43,7 @@ while IFS= read -r skill_dir; do
   name="$(skill_name_from_dir "$skill_dir")"
   case "$skill_dir" in
     ./skills/akka-*) akka+=("$name") ;;
-    ./skills/csharp-*) csharp+=("$name") ;;
+    ./skills/csharp-*|./skills/r3-*) csharp+=("$name") ;;
     ./skills/aspire-*|./skills/mjml-*) aspnetcore_web+=("$name") ;;
     ./skills/efcore-*|./skills/database-*) data+=("$name") ;;
     ./skills/microsoft-extensions-*) di_config+=("$name") ;;

--- a/skills/r3-reactive-extensions/SKILL.md
+++ b/skills/r3-reactive-extensions/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: r3-reactive-extensions
+description: Build reactive/event-driven C# with R3 (Cysharp's modern reimplementation of Reactive Extensions). Covers the Observable<T>/Observer<T> model, the OnErrorResume error contract, async dispatch with AwaitOperation, Task/IAsyncEnumerable integration, TimeProvider/FrameProvider scheduling, the concurrency contract, and how R3 differs from System.Reactive (Rx.NET).
+invocable: false
+---
+
+# R3: Modern Reactive Extensions for .NET
+
+R3 is [Cysharp's](https://github.com/Cysharp/R3) ground-up reimplementation of Reactive
+Extensions — "the new future of dotnet/reactive and UniRx." It keeps the LINQ-over-events
+programming model but rebuilds the core types, error contract, and scheduler to fix
+long-standing problems in `System.Reactive` (Rx.NET). Use this skill when composing event
+streams, UI input, timers, or push-based pipelines in C#.
+
+**Canonical sources** (link to these from code and docs):
+- Repository: https://github.com/Cysharp/R3
+- README (full operator reference): https://github.com/Cysharp/R3/blob/main/README.md
+- Author's design rationale: https://neuecc.medium.com/r3-a-new-modern-reimplementation-of-reactive-extensions-for-c-cf29abcc5826
+
+## When to Use This Skill
+
+Use this skill when:
+- Composing **events** over time — UI input, sensor/feed updates, websocket messages, domain events
+- You need operators like debounce, throttle, merge, combine-latest, distinct-until-changed
+- Building **MVVM** state with `ReactiveProperty` / `BindableReactiveProperty`
+- Bridging push-based streams with `Task` / `async` and `IAsyncEnumerable`
+- Migrating from `System.Reactive`, UniRx, or `IObservable<T>` code
+- You hit Rx pain points: subscriptions dying on exceptions, scheduler overhead, or leak hunting
+
+**Not the right tool for:** request/response I/O (use `async/await`), bounded producer/consumer
+with **backpressure** (use `System.Threading.Channels`), or server-side stream processing with
+batching/backpressure (use Akka.NET Streams). R3, like all Rx, is **push-based with no
+backpressure**. See the `csharp-concurrency-patterns` skill for choosing between these.
+
+## Reference Files
+
+- [rx-net-differences.md](rx-net-differences.md): Every meaningful difference vs System.Reactive (Rx.NET) — the new core types, the error model, operator renames, dropped APIs, the scheduler swap, and a migration checklist.
+- [async-and-integration-patterns.md](async-and-integration-patterns.md): Common patterns — async dispatch with `AwaitOperation`, `Task` integration, `IAsyncEnumerable` round-tripping, `ReactiveProperty`/MVVM, subjects, and subscription lifecycle.
+- [scheduling-and-concurrency.md](scheduling-and-concurrency.md): How R3 handles **concurrent updates** (the threading contract, `Synchronize`, `ObserveOn`), `TimeProvider` vs `FrameProvider`, when each is necessary, and deterministic testing with fake providers.
+
+> Everything in this skill was validated empirically against **R3 1.3.1**. Captured output
+> appears in the reference files as evidence.
+
+---
+
+## Why R3 Exists (the "why use it")
+
+The author ([neuecc](https://neuecc.medium.com/r3-a-new-modern-reimplementation-of-reactive-extensions-for-c-cf29abcc5826))
+built R3 to fix concrete defects in `System.Reactive`:
+
+1. **Exceptions silently kill subscriptions.** In Rx, one exception in the pipeline calls
+   `OnError` and *unsubscribes forever* — "a billion-dollar mistake" for long-lived event
+   streams (a single bad UI event tears down the whole subscription). R3 routes errors to
+   `OnErrorResume` and **keeps the subscription alive by default**.
+2. **`IScheduler` is heavy and confusing.** `ImmediateScheduler`/`Merge` were measured causing
+   real server memory/CPU bloat. R3 deletes `IScheduler` and uses .NET 8's `TimeProvider`
+   (wall-clock) plus a new `FrameProvider` (frame-clock).
+3. **Subscription leaks are hard to find.** R3 makes every `Observable<T>` an abstract class so
+   all subscriptions funnel through one place, enabling `ObservableTracker` to list every live
+   subscription with stack traces.
+4. **Rx and async were awkwardly fused.** R3 treats Rx as **event-first** and adds explicit
+   bridges (`AwaitOperation`, `FromAsync`, `ToAsyncEnumerable`) instead of pretending events
+   are pull-based sequences.
+5. **One library, every UI.** A platform-neutral core plus thin provider packages for Unity,
+   Godot, WPF, WinForms, Avalonia, WinUI3, MAUI, Stride, MonoGame, and Blazor.
+
+---
+
+## Install
+
+```bash
+dotnet add package R3
+# Platform glue (pick what applies): R3.WPF, R3.Avalonia, R3.WinForms, R3.Unity (UPM),
+# R3.Godot, ObservableCollections.R3, etc. See the repo README for the full list.
+```
+
+```csharp
+using R3;
+```
+
+---
+
+## The Mental Model
+
+R3 replaces Rx's **interfaces** with **abstract classes**, and replaces Rx's two-method error
+contract with a single completion that carries a result.
+
+```csharp
+public abstract class Observable<T>
+{
+    public IDisposable Subscribe(Observer<T> observer);     // tracked centrally
+    protected abstract IDisposable SubscribeCore(Observer<T> observer);
+}
+
+public abstract class Observer<T> : IDisposable               // the observer IS the subscription
+{
+    public void OnNext(T value);
+    public void OnErrorResume(Exception error);               // error WITHOUT unsubscribing
+    public void OnCompleted(Result result);                   // success OR failure terminates
+}
+```
+
+The grammar is `(OnNext | OnErrorResume)* OnCompleted(Result)?`. Note the difference from Rx's
+`OnNext* (OnError | OnCompleted)?`: **errors and termination are decoupled**. An error is just a
+notification; only `OnCompleted` ends the stream, and it carries a `Result` that is either
+`Result.Success` or `Result.Failure(exception)`.
+
+### Quick start
+
+```csharp
+using R3;
+
+var subscription = Observable
+    .EveryValueChanged(model, m => m.SearchText)   // emits when the property changes
+    .Debounce(TimeSpan.FromMilliseconds(300))      // Rx called this "Throttle" (see differences)
+    .DistinctUntilChanged()
+    .SubscribeAwait(async (text, ct) =>
+    {
+        var results = await _api.SearchAsync(text, ct);
+        Render(results);
+    }, AwaitOperation.Switch);                      // cancel the in-flight search on a new keystroke
+
+// Dispose to unsubscribe; or route into a DisposableBag / AddTo(token).
+subscription.Dispose();
+```
+
+---
+
+## Core Behavior, Verified
+
+### Errors do not terminate by default
+
+```csharp
+var subject = new Subject<int>();
+subject.Select(x => 100 / x).Subscribe(
+    onNext:        x => Console.WriteLine($"next {x}"),
+    onErrorResume: e => Console.WriteLine($"errorResume {e.GetType().Name}"),
+    onCompleted:   (Result r) => Console.WriteLine($"completed IsSuccess={r.IsSuccess}"));
+
+subject.OnNext(2);   // next 50
+subject.OnNext(0);   // errorResume DivideByZeroException   <-- NOT terminated
+subject.OnNext(5);   // next 20                             <-- subscription is still alive!
+subject.OnCompleted(); // completed IsSuccess=True
+```
+
+This is the single biggest behavioral change from Rx. To opt back into classic "an error
+terminates the sequence" behavior, insert `.OnErrorResumeAsFailure()` — the error then flows to
+`OnCompleted(Result.Failure(e))` and downstream `OnNext`s stop. Recover with `Catch`. Full
+captured runs and the (deliberately absent) `Retry` story are in
+[rx-net-differences.md](rx-net-differences.md).
+
+### Async dispatch is explicit
+
+R3's async operators (`SubscribeAwait`, `SelectAwait`, `WhereAwait`, …) take an `AwaitOperation`
+that decides what happens when values arrive faster than the async work completes:
+
+| `AwaitOperation` | Overlap behavior | Typical use |
+|------------------|------------------|-------------|
+| `Sequential` (default) | Queue values, run one at a time | Ordered processing |
+| `Drop` | Ignore new values while one is running | Debounced submit / cooldown |
+| `Switch` | Cancel the running one, start the new | Search-as-you-type, latest-wins |
+| `Parallel` | Run all concurrently | Independent fan-out |
+| `SequentialParallel` | Run concurrently, emit results in order | Parallel map, ordered output |
+| `ThrottleFirstLast` | Run first + last of a burst | Leading/trailing sampling |
+
+These were verified to behave exactly as described (including `Switch` cancelling the superseded
+operation's `CancellationToken`). See [async-and-integration-patterns.md](async-and-integration-patterns.md).
+
+### Task and IAsyncEnumerable bridges
+
+```csharp
+// Task -> Observable
+await Observable.FromAsync(async ct => await LoadAsync(ct)).FirstAsync();
+
+// Observable -> Task (terminal operators return Task<T>)
+List<int> all = await source.ToListAsync();
+int last      = await source.LastAsync();
+
+// IAsyncEnumerable -> Observable, and back
+await asyncEnumerable.ToObservable().ForEachAsync(Handle);
+await foreach (var x in source.ToAsyncEnumerable()) { /* ... */ }
+```
+
+All verified working. Details and the full terminal-operator list are in
+[async-and-integration-patterns.md](async-and-integration-patterns.md).
+
+---
+
+## How R3 Handles Concurrent Updates
+
+**R3 does not serialize concurrent producers.** Like Rx, it assumes the Rx grammar: `OnNext`
+must not be called concurrently or re-entrantly from multiple threads. Operators (`Where`,
+`Select`, `Subject`, …) are **not internally locked**. Pushing `OnNext` from many threads at once
+into a stateful downstream **corrupts state** — in testing, 20,000 concurrent `OnNext` calls into
+a `List<T>` subscriber lost ~half the items and threw inside the operator chain.
+
+The fix is to make the boundary explicit:
+
+```csharp
+// Multiple producer threads -> one serialized consumer
+subject.Synchronize()                  // lock-based gate; delivery becomes single-threaded
+       .Where(x => x.IsValid)
+       .Subscribe(Handle);             // verified: 10000/10000 items, no corruption
+
+// Or marshal onto a context/threadpool, which also serializes delivery:
+source.ObserveOnThreadPool().Subscribe(Handle);
+
+// For shared MVVM state written from many threads:
+var counter = new SynchronizedReactiveProperty<int>(0);   // thread-safe writes
+```
+
+**Practical rule:** if more than one thread can publish into a stream, put `Synchronize()` (or an
+`ObserveOn*`) immediately after the source, or use `SynchronizedReactiveProperty`. Full race
+reproductions and outputs are in [scheduling-and-concurrency.md](scheduling-and-concurrency.md).
+
+---
+
+## Time vs Frames: TimeProvider and FrameProvider
+
+R3 has **two** notions of "when," and both are abstractions you can fake in tests:
+
+- **`TimeProvider`** (the .NET 8 BCL type) = wall-clock time. Used by `Delay`, `Debounce`,
+  `Interval`, `Timer`, `Timeout`. This is what server/business code uses.
+- **`FrameProvider`** (R3-specific) = a *frame clock*. Used by `EveryUpdate`, `DelayFrame(n)`,
+  `IntervalFrame(n)`, etc.
+
+**When is a FrameProvider necessary?** Whenever "progress" is measured in render/update ticks
+instead of elapsed time:
+- **Game engines** (Unity, Godot, Stride, MonoGame) — logic ticks with the engine's update loop,
+  so it respects pause and time-scale and stays in lockstep with rendering.
+- **UI render loops** (WPF/Avalonia/WinUI composition frames) — react per frame.
+- **Deterministic tests** — `FakeFrameProvider.Advance(n)` drives frames with zero real time,
+  exactly as `FakeTimeProvider.Advance(timeSpan)` drives the clock.
+
+Plain server/business code virtually never needs `FrameProvider` — that's `TimeProvider`
+territory. Both fakes make time-dependent pipelines fully deterministic; examples in
+[scheduling-and-concurrency.md](scheduling-and-concurrency.md).
+
+---
+
+## Best Practices Summary
+
+### DO
+- Treat `OnErrorResume` as the default: design streams that survive individual bad events.
+- Add `.OnErrorResumeAsFailure()` when you genuinely want an error to terminate the stream.
+- Choose an `AwaitOperation` deliberately for every async operator (`Switch` for latest-wins,
+  `Sequential` for ordering, `Drop` for cooldowns).
+- Put `Synchronize()` / `ObserveOn*` after any source that multiple threads publish into.
+- Pass a `TimeProvider` to time operators and a `FrameProvider` to frame operators so tests can
+  use `FakeTimeProvider` / `FakeFrameProvider`.
+- Manage lifetime: route subscriptions into a `DisposableBag`, `CompositeDisposable`, or
+  `.AddTo(cancellationToken)`; turn on `ObservableTracker` in dev to catch leaks.
+- Use `ReactiveProperty` for de-duplicated observable state; `BindableReactiveProperty` for
+  XAML-bound state.
+
+### DON'T
+- Don't assume an exception ends the stream (that's Rx, not R3).
+- Don't reach for Rx names that R3 renamed: it's `Debounce` (not `Throttle`), `ThrottleLast`
+  (not `Sample`), `Chunk` (not `Buffer`). `Retry`, `GroupBy`, `Finally`, and plain `Buffer` are
+  **absent** in 1.3.1 — see the differences file for replacements.
+- Don't call `OnNext` concurrently/re-entrantly from multiple threads without `Synchronize()`.
+- Don't use R3 for backpressured throughput pipelines — use Channels or Akka.NET Streams.
+- Don't block on terminal operators (`.Result`/`.Wait()`); they return `Task<T>` — `await` them.
+
+---
+
+## Additional Resources
+
+- **R3 repository:** https://github.com/Cysharp/R3
+- **Full README / operator reference:** https://github.com/Cysharp/R3/blob/main/README.md
+- **Design rationale (neuecc):** https://neuecc.medium.com/r3-a-new-modern-reimplementation-of-reactive-extensions-for-c-cf29abcc5826
+- **NuGet:** https://www.nuget.org/packages/R3
+- **`TimeProvider` (BCL):** https://learn.microsoft.com/en-us/dotnet/api/system.timeprovider
+- **`FakeTimeProvider`:** https://www.nuget.org/packages/Microsoft.Extensions.TimeProvider.Testing
+- **Related skill:** `csharp-concurrency-patterns` (choosing R3 vs async/await vs Channels vs Akka.NET)

--- a/skills/r3-reactive-extensions/async-and-integration-patterns.md
+++ b/skills/r3-reactive-extensions/async-and-integration-patterns.md
@@ -1,0 +1,232 @@
+# R3 Common Patterns: Async, Task, IAsyncEnumerable, MVVM
+
+Day-to-day patterns for R3, with emphasis on async dispatch and bridging to `Task` /
+`IAsyncEnumerable`. Verified against **R3 1.3.1**. Operator reference:
+[R3 README](https://github.com/Cysharp/R3/blob/main/README.md).
+
+## Contents
+- Async dispatch with `AwaitOperation`
+- The async operators (`SubscribeAwait`, `SelectAwait`, `WhereAwait`)
+- Task integration (in and out)
+- IAsyncEnumerable round-tripping
+- Creating observables (events, properties, factories)
+- ReactiveProperty and MVVM
+- Subjects: which one to use
+- Subscription lifecycle and disposal
+
+---
+
+## Async dispatch with `AwaitOperation`
+
+The defining feature of R3's async story: async operators take an `AwaitOperation` enum that
+controls what happens when values arrive faster than the async handler completes. The full
+enum (verified): `Sequential, Drop, Switch, Parallel, SequentialParallel, ThrottleFirstLast`.
+
+The POC below emits `1, 2, 3` back-to-back; each handler sleeps 100 ms. Captured output per mode
+makes the semantics concrete:
+
+```csharp
+subject.SubscribeAwait(async (x, ct) =>
+{
+    Log($"start {x}");
+    await Task.Delay(100, ct);
+    Log($"end {x}");
+}, awaitOperation);   // <-- the mode
+```
+
+```text
+--- Sequential: queue, one at a time ---
+[  13ms] start 1   [ 118ms] end 1   [ 118ms] start 2   [ 218ms] end 2   [ 218ms] start 3   [ 318ms] end 3
+
+--- Drop: ignore arrivals while busy ---
+[   0ms] start 1   [ 100ms] end 1            (2 and 3 dropped)
+
+--- Switch: cancel running, start newest ---
+[   0ms] start 1   [   1ms] start 2   [   1ms] start 3
+[   9ms] CANCELLED 1   [   9ms] CANCELLED 2   [ 101ms] end 3
+
+--- Parallel: all at once ---
+[   0ms] start 1   [   1ms] start 2   [   1ms] start 3   [ ~100ms] end 3 / end 2 / end 1
+```
+
+Choosing a mode:
+
+| Mode | Use it for |
+|---|---|
+| `Sequential` (default) | Order matters; never overlap (e.g. apply writes in order) |
+| `Drop` | Cooldown / debounced submit — ignore clicks while one is in flight |
+| `Switch` | Latest-wins — search-as-you-type, autocomplete, live preview |
+| `Parallel` | Independent fan-out where order doesn't matter |
+| `SequentialParallel` | Run concurrently but emit results in source order |
+| `ThrottleFirstLast` | Sample the leading and trailing item of a burst |
+
+`Switch` cancels the superseded operation's `CancellationToken` (note the `CANCELLED 1/2`
+above) — so a handler that honors `ct` stops wasted work immediately.
+
+## The async operators
+
+All async operators share the shape `Func<T, CancellationToken, ValueTask<...>>` plus the
+`AwaitOperation` and a few knobs (`configureAwait`, `cancelOnCompleted`, `maxConcurrent`):
+
+```csharp
+// Subscribe with async handler
+source.SubscribeAwait(
+    async (x, ct) => await HandleAsync(x, ct),
+    AwaitOperation.Sequential,
+    configureAwait: true,
+    cancelOnCompleted: true,
+    maxConcurrent: -1);
+
+// Project asynchronously -> Observable<TResult>
+source.SelectAwait(async (x, ct) => await LoadAsync(x, ct), AwaitOperation.Switch);
+
+// Filter asynchronously
+source.WhereAwait(async (x, ct) => await IsAllowedAsync(x, ct), AwaitOperation.Sequential);
+```
+
+`maxConcurrent` bounds `Parallel`/`SequentialParallel` concurrency. `cancelOnCompleted` cancels
+the in-flight `ct` when the source completes.
+
+## Task integration (in and out)
+
+**Task → Observable.** Lift an async operation into a one-shot stream:
+
+```csharp
+var value = await Observable
+    .FromAsync(async ct => { await Task.Delay(10, ct); return 42; })
+    .FirstAsync();                       // -> 42  (verified)
+```
+
+**Observable → Task.** Every "collapse to one result" operator is a `*Async` returning `Task<T>`
+— `await` them (verified):
+
+```csharp
+List<int> all  = await source.ToListAsync();
+int[]     arr  = await source.ToArrayAsync();
+int       first= await source.FirstAsync();
+int       last = await source.LastAsync();
+int       count= await source.CountAsync();
+```
+
+Other terminals include `SingleAsync`, `ElementAtAsync`, `SumAsync`, `MinAsync`, `MaxAsync`,
+`AggregateAsync`, `ToDictionaryAsync`, `ToHashSetAsync`, `ContainsAsync`, `AnyAsync`, `AllAsync`,
+`IsEmptyAsync`. `ForEachAsync(Func<T, ValueTask>)` awaits the whole stream with a per-item async
+action; `WaitAsync(timeout)` adds a timeout.
+
+## IAsyncEnumerable round-tripping
+
+R3 bridges both directions (verified):
+
+```csharp
+// IAsyncEnumerable<T> -> Observable<T>
+static async IAsyncEnumerable<int> Gen()
+{
+    for (int i = 1; i <= 3; i++) { await Task.Delay(5); yield return i * 10; }
+}
+await Gen().ToObservable().ForEachAsync(x => received.Add(x));   // received: [10, 20, 30]
+
+// Observable<T> -> IAsyncEnumerable<T>
+await foreach (var x in Observable.Range(1, 3).ToAsyncEnumerable())   // 1, 2, 3
+    Process(x);
+```
+
+Rule of thumb from the author: use `IAsyncEnumerable` for **pull**-based / network sequences and
+R3 for **push**-based events; the bridges let you cross over at the seams.
+
+## Creating observables (events, properties, factories)
+
+```csharp
+// From a .NET event
+Observable.FromEvent<EventHandler, EventArgs>(
+    h => (s, e) => h(e),
+    h => button.Click += h,
+    h => button.Click -= h);
+
+// From INotifyPropertyChanged property changes
+viewModel.ObservePropertyChanged(vm => vm.Name);
+
+// Poll-free property watching (frame-based; great for game/UI state)
+Observable.EveryValueChanged(model, m => m.Health);
+
+// Custom producer
+Observable.Create<int>(observer =>
+{
+    observer.OnNext(1);
+    observer.OnCompleted();
+    return Disposable.Empty;
+});
+
+// Timers / ranges / single values
+Observable.Range(1, 10);
+Observable.Return(42);
+Observable.Interval(TimeSpan.FromSeconds(1), timeProvider);
+```
+
+## ReactiveProperty and MVVM
+
+`ReactiveProperty<T>` is the workhorse for observable state: it holds a current `.Value`, replays
+it to new subscribers, and suppresses consecutive duplicates by default (verified):
+
+```csharp
+var health = new ReactiveProperty<int>(100);
+health.Subscribe(v => Console.WriteLine($"health = {v}"));  // immediately prints 100
+health.Value = 100;   // suppressed (duplicate)
+health.Value = 80;    // health = 80
+
+// Derive read-only state from any observable:
+ReadOnlyReactiveProperty<bool> isLow =
+    health.Select(v => v < 25).ToReadOnlyReactiveProperty(false);
+Console.WriteLine(isLow.CurrentValue);   // current snapshot without subscribing
+```
+
+For XAML/data-binding hosts (WPF, Avalonia, WinUI, MAUI), use `BindableReactiveProperty<T>`
+(implements `INotifyPropertyChanged`) and `ReactiveCommand` for bound commands:
+
+```csharp
+public BindableReactiveProperty<string> Name { get; } = new("");
+public ReactiveCommand<Unit> Save { get; }
+
+Save = Name.Select(n => !string.IsNullOrEmpty(n)).ToReactiveCommand();   // enabled when name set
+Save.SubscribeAwait(async (_, ct) => await SaveAsync(ct), AwaitOperation.Drop);
+```
+
+## Subjects: which one to use
+
+| Type | Replays to new subscribers | De-duplicates | Use for |
+|---|---|---|---|
+| `Subject<T>` | no | no | plain multicast hub |
+| `BehaviorSubject<T>` | current value | no | "last value + future" without de-dup |
+| `ReactiveProperty<T>` | current value | **yes** (distinct-until-changed) | observable state / MVVM |
+| `ReplaySubject<T>` | buffered history | no | late subscribers need past values |
+| `SynchronizedReactiveProperty<T>` | current value | yes | state written from multiple threads |
+
+Verified: `ReplaySubject` replays its buffer to a subscriber that attaches *after* emissions; a
+late subscriber to `new ReplaySubject<int>()` that already saw `1,2,3` receives `[1, 2, 3]`.
+
+## Subscription lifecycle and disposal
+
+Every `Subscribe` returns an `IDisposable`. Manage many at once with R3's disposal helpers
+(roughly fastest → most flexible):
+
+```csharp
+// Struct builder — zero-alloc, fixed at build time
+var builder = Disposable.CreateBuilder();
+source1.Subscribe(...).AddTo(ref builder);
+source2.Subscribe(...).AddTo(ref builder);
+IDisposable all = builder.Build();
+
+// DisposableBag — struct field, add-only, dispose together
+DisposableBag bag = default;
+source.Subscribe(...).AddTo(ref bag);
+// bag.Dispose();
+
+// CompositeDisposable — class, thread-safe, supports Remove
+var disposables = new CompositeDisposable();
+source.Subscribe(...).AddTo(disposables);
+
+// Tie a subscription to a CancellationToken (auto-dispose on cancel)
+source.Subscribe(...).AddTo(cancellationToken);
+```
+
+In development, turn on `ObservableTracker.EnableTracking = true` (and `EnableStackTrace = true`)
+and call `ObservableTracker.ForEachActiveTask(...)` to find subscriptions you forgot to dispose.

--- a/skills/r3-reactive-extensions/rx-net-differences.md
+++ b/skills/r3-reactive-extensions/rx-net-differences.md
@@ -1,0 +1,258 @@
+# R3 vs System.Reactive (Rx.NET): Differences
+
+How R3 differs from `System.Reactive` (Rx.NET) and UniRx, with the reasoning behind each change.
+All API facts below were verified by reflection and runtime POCs against **R3 1.3.1**. The
+authoritative reference is the [R3 README](https://github.com/Cysharp/R3/blob/main/README.md);
+the rationale is in the [author's article](https://neuecc.medium.com/r3-a-new-modern-reimplementation-of-reactive-extensions-for-c-cf29abcc5826).
+
+## Contents
+- The big picture
+- Difference 1: Abstract classes, not interfaces
+- Difference 2: The error model (`OnErrorResume` + `Result`)
+- Difference 3: No `IScheduler` — `TimeProvider` + `FrameProvider`
+- Difference 4: Operator renames
+- Difference 5: Dropped / `*Async`-only operators
+- Difference 6: Subjects and single-value sequences
+- Difference 7: Built-in subscription-leak tracking
+- Difference 8: Interop with System.Reactive
+- Difference 9: Performance posture
+- Migration checklist
+
+---
+
+## The big picture
+
+| Concern | System.Reactive (Rx.NET) | R3 |
+|---|---|---|
+| Core abstraction | `IObservable<T>` / `IObserver<T>` interfaces | `Observable<T>` / `Observer<T>` **abstract classes** |
+| Observer methods | `OnNext`, `OnError`, `OnCompleted` | `OnNext`, `OnErrorResume`, `OnCompleted(Result)` |
+| Exception default | Terminates + unsubscribes | **Continues** (error is a notification) |
+| Scheduling | `IScheduler` (+ sub-interfaces) | `TimeProvider` (wall-clock) + `FrameProvider` (frame-clock) |
+| Subscription handle | separate `IDisposable` | the `Observer<T>` **is** the `IDisposable` |
+| Leak diagnostics | none built in | `ObservableTracker` lists live subscriptions |
+| Async bridge | `ToTask`, ad-hoc | `AwaitOperation` operators, `FromAsync`, `ToAsyncEnumerable` |
+| Reach | .NET (+ UI libs) | .NET core + Unity, Godot, WPF, WinForms, Avalonia, WinUI3, MAUI, Stride, MonoGame, Blazor |
+
+---
+
+## Difference 1: Abstract classes, not interfaces
+
+R3 makes `Observable<T>` and `Observer<T>` abstract classes. The author's stated reason: *"to
+centralize management of all subscriptions. All Subscribes must go through the base class's
+Subscribe implementation, enabling tracking of subscriptions."*
+
+```csharp
+public abstract class Observable<T>
+{
+    public IDisposable Subscribe(Observer<T> observer);          // sealed entry point; tracks then calls:
+    protected abstract IDisposable SubscribeCore(Observer<T> observer);
+}
+
+public abstract class Observer<T> : IDisposable                  // observer doubles as the subscription
+{
+    public void OnNext(T value);
+    public void OnErrorResume(Exception error);
+    public void OnCompleted(Result result);
+    protected abstract void OnNextCore(T value);
+    protected abstract void OnErrorResumeCore(Exception error);
+    protected abstract void OnCompletedCore(Result result);
+}
+```
+
+Consequences:
+- You can no longer declare `IObservable<T>` and get Rx for free; you derive from
+  `Observable<T>` or (almost always) use factory methods and operators.
+- The observer being its own `IDisposable` removes a per-subscription allocation.
+- Custom operators override the `*Core` methods, and disposal is centralized and thread-safe
+  (single-execution via `Interlocked`).
+
+## Difference 2: The error model (`OnErrorResume` + `Result`)
+
+This is the most important behavioral difference. In Rx, `OnError` is terminal — a single
+exception anywhere in the pipeline unsubscribes everything. The author calls automatic
+unsubscription-on-exception *"a billion-dollar mistake in Rx"*: real event sources (UI, sensors,
+sockets) should not die because one event threw.
+
+In R3:
+- Exceptions flow to **`OnErrorResume`** and the **subscription stays alive**.
+- Termination is a separate event, `OnCompleted(Result)`, where `Result` is a readonly struct:
+  `Result.Success` (a property) or `Result.Failure(Exception)` (a static method), exposing
+  `IsSuccess`, `IsFailure`, `Exception`, and `TryThrow()`.
+
+Verified against R3 1.3.1:
+
+```csharp
+var subject = new Subject<int>();
+subject.Select(x => 100 / x).Subscribe(
+    onNext:        x => Console.WriteLine($"next {x}"),
+    onErrorResume: e => Console.WriteLine($"errorResume {e.GetType().Name}"),
+    onCompleted:   (Result r) => Console.WriteLine($"completed IsSuccess={r.IsSuccess} IsFailure={r.IsFailure}"));
+
+subject.OnNext(2);   subject.OnNext(0);   subject.OnNext(5);   subject.OnCompleted();
+```
+```text
+next 50
+errorResume DivideByZeroException
+next 20                                  <-- still alive after the error
+completed IsSuccess=True
+```
+
+To get classic Rx "an error ends the stream" semantics, insert `OnErrorResumeAsFailure()`. The
+exception is then delivered as `OnCompleted(Result.Failure(e))` and later values are dropped:
+
+```csharp
+subject.Select(x => 100 / x)
+       .OnErrorResumeAsFailure()
+       .Subscribe(onNext: x => ..., onCompleted: r => Console.WriteLine($"IsFailure={r.IsFailure} {r.Exception?.GetType().Name}"));
+// next 50
+// completed IsFailure=True DivideByZeroException     (a subsequent OnNext(5) never arrives)
+```
+
+Recovery uses `Catch` (verified). A burst of substitution:
+
+```csharp
+source.Select(x => 100 / x)
+      .OnErrorResumeAsFailure()
+      .Catch((DivideByZeroException _) => Observable.Return(-1))
+      .Subscribe(...);   // emits 25, then -1 in place of the divide-by-zero, then completes Success
+```
+
+**Watch out:** an exception thrown inside the *terminal* `Subscribe` callback (not an operator)
+has no downstream `OnErrorResume` to catch it, so it goes to R3's **global unhandled-exception
+handler** (`ObservableSystem.RegisterUnhandledExceptionHandler(...)`), not to the caller.
+
+## Difference 3: No `IScheduler` — `TimeProvider` + `FrameProvider`
+
+R3 deletes `IScheduler` and its tangle of sub-interfaces (`ISchedulerLongRunning`,
+`ISchedulerPeriodic`, `IStopwatchProvider`). Time-based operators take a **`TimeProvider`** (the
+.NET 8 BCL abstraction). Frame-based operators take a **`FrameProvider`** (new in R3).
+
+```csharp
+// Rx:  Observable.Timer(dueTime, scheduler)
+// R3:  pass a TimeProvider (defaults to TimeProvider.System)
+Observable.Timer(TimeSpan.FromSeconds(1), timeProvider);
+Observable.Interval(TimeSpan.FromSeconds(1), timeProvider);
+source.Debounce(TimeSpan.FromMilliseconds(300), timeProvider);
+
+// Frame clock (game/UI loops) has no Rx equivalent:
+Observable.EveryUpdate(frameProvider);
+source.DelayFrame(2, frameProvider);
+```
+
+Why: `TimeProvider.CreateTimer()`/`GetTimestamp()` are cheaper than Rx's recursive
+`Schedule` calls, and the BCL type is testable out of the box with `FakeTimeProvider`. See
+`scheduling-and-concurrency.md` (sibling) for the testing patterns and the frame-vs-time decision.
+
+## Difference 4: Operator renames
+
+R3 fixes Rx's most confusing operator names. Verified by reflecting the operator surface — the
+**old names do not exist** in R3 1.3.1:
+
+| Rx.NET name | R3 name | Notes |
+|---|---|---|
+| `Throttle` | **`Debounce`** | "wait for quiet" — R3 uses the name everyone actually means |
+| `Sample` | **`ThrottleLast`** | emit the last value per interval |
+| *(n/a)* | **`ThrottleFirst`** | emit the first value per interval (new) |
+| *(n/a)* | **`ThrottleFirstLast`** | first + last of a window (new) |
+| `Buffer` | **`Chunk`** | matches LINQ's `Chunk`; also `ChunkFrame`, `ChunkUntil` |
+
+Every time operator also has a `*Frame` sibling (`DebounceFrame`, `ThrottleLastFrame`,
+`IntervalFrame`, `DelayFrame`, `TimeoutFrame`, …) for the frame clock.
+
+## Difference 5: Dropped / `*Async`-only operators
+
+Some Rx operators are intentionally gone or reshaped in 1.3.1 (verified absent by reflection).
+Don't reach for these out of Rx muscle memory:
+
+| Rx.NET | Status in R3 1.3.1 | Replacement |
+|---|---|---|
+| `Retry` | **absent** | `OnErrorResumeAsFailure()` then `Catch`/`Repeat`; or re-subscribe explicitly |
+| `GroupBy` | **absent** | partition manually / use `ObservableCollections` groupings |
+| `Finally` | **absent** | `Do(onCompleted/onDispose)` or dispose-side handling |
+| `Buffer` | **absent** (renamed) | `Chunk` |
+| `Aggregate` | only `AggregateAsync` | `await source.AggregateAsync(...)` |
+| `SequenceEqual` | only `SequenceEqualAsync` | `await source.SequenceEqualAsync(...)` |
+| `First`/`Last`/`Single`/`Count`/`Sum`/`ToList`/`ToArray` | `*Async`, return `Task<T>` | `await source.FirstAsync()` etc. |
+
+The pattern: anything that collapses a stream to **one value** is a `*Async` method returning
+`Task<T>` — because in R3, "give me the single result" is a pull/await operation, not a one-shot
+observable. `FlatMap` is named `SelectMany` (LINQ-consistent).
+
+## Difference 6: Subjects and single-value sequences
+
+R3 ships a focused set of subjects (verified present): `Subject<T>`, `BehaviorSubject<T>`,
+`ReplaySubject<T>`, `ReplayFrameSubject<T>`, plus the property-style hubs `ReactiveProperty<T>`,
+`ReadOnlyReactiveProperty<T>`, `BindableReactiveProperty<T>`, and `SynchronizedReactiveProperty<T>`.
+
+The notable change from Rx is **`ReactiveProperty<T>`**, the modern `BehaviorSubject`
+replacement. Both replay the current value to new subscribers, but they differ in de-duplication
+(verified):
+
+```csharp
+// ReactiveProperty: distinct-until-changed by DEFAULT
+var rp = new ReactiveProperty<int>(1);
+rp.Subscribe(received.Add);
+rp.Value = 1; rp.Value = 1; rp.Value = 2; rp.Value = 2; rp.Value = 3;
+// received: [1, 2, 3]          <-- consecutive duplicates suppressed
+
+// BehaviorSubject: replays, but does NOT de-duplicate
+var bs = new BehaviorSubject<int>(100);
+bs.Subscribe(received.Add);
+bs.OnNext(100); bs.OnNext(100); bs.OnNext(200);
+// received: [100, 100, 100, 200]
+```
+
+`AsyncSubject` (Rx's "remember the last value at completion") is gone — that role is served by
+awaiting `LastAsync()`.
+
+## Difference 7: Built-in subscription-leak tracking
+
+R3 ships `ObservableTracker`, enabled by setting public static fields:
+
+```csharp
+ObservableTracker.EnableTracking = true;
+ObservableTracker.EnableStackTrace = true;     // capture where each subscription was created
+ObservableTracker.ForEachActiveTask(state => Console.WriteLine(state));
+```
+
+This is the payoff of Difference 1 (centralized `Subscribe`). Unity gets an editor window; other
+hosts can dump active subscriptions on demand. Rx has no equivalent.
+
+## Difference 8: Interop with System.Reactive
+
+R3 is a separate type system, so it provides explicit bridges (present in the operator surface):
+- `AsSystemObservable()` — expose an R3 `Observable<T>` as an `IObservable<T>` for code that
+  expects Rx.NET.
+- `ToObservable()` — adapt an `IObservable<T>` (and `IEnumerable<T>`, `IAsyncEnumerable<T>`,
+  `Task<T>`) into an R3 `Observable<T>`.
+
+This lets you adopt R3 incrementally at the edges of an existing Rx.NET codebase.
+
+## Difference 9: Performance posture
+
+R3's design choices are largely performance-driven (per the author's article):
+- `TimeProvider.CreateTimer` instead of allocating a new timer per `Schedule`.
+- The observer-is-the-subscription design removes a wrapper allocation per `Subscribe`.
+- Raw timestamps (`GetTimestamp`) instead of `DateTimeOffset` math.
+- Struct-based disposable containers (`DisposableBag`, `Disposable.CreateBuilder`) to avoid
+  per-subscription `CompositeDisposable` overhead.
+
+The author specifically cites Rx's `ImmediateScheduler`/`Merge` causing measurable server memory
+and CPU bloat as a motivating case. (Treat exact numbers as version-dependent; benchmark your own
+hot paths.)
+
+## Migration checklist
+
+When porting Rx.NET / UniRx code to R3:
+
+1. Replace `using System.Reactive.Linq;` with `using R3;`.
+2. Replace `IObservable<T>`/`IObserver<T>` declarations with `Observable<T>`/`Observer<T>`.
+3. Split `OnError` handling: decide per stream whether errors should **resume** (default,
+   handle in `onErrorResume`) or **terminate** (add `OnErrorResumeAsFailure()`).
+4. Change `onCompleted: () => ...` to `onCompleted: (Result r) => ...`.
+5. Rename operators: `Throttle`→`Debounce`, `Sample`→`ThrottleLast`, `Buffer`→`Chunk`.
+6. Convert single-value operators to `await ...Async()` (`First`→`FirstAsync`, etc.).
+7. Replace `IScheduler` arguments with a `TimeProvider` (or `FrameProvider` for frame loops).
+8. Replace `BehaviorSubject` with `ReactiveProperty` where you want de-duplicated state.
+9. Replace `Retry`/`GroupBy`/`Finally` usages with the alternatives above.
+10. Add lifetime management (`DisposableBag`/`AddTo`) and turn on `ObservableTracker` in dev.

--- a/skills/r3-reactive-extensions/scheduling-and-concurrency.md
+++ b/skills/r3-reactive-extensions/scheduling-and-concurrency.md
@@ -1,0 +1,187 @@
+# R3 Scheduling & Concurrency
+
+How R3 handles concurrent updates, thread marshaling, and time — plus deterministic testing.
+All behavior verified against **R3 1.3.1**. Reference:
+[R3 README](https://github.com/Cysharp/R3/blob/main/README.md).
+
+## Contents
+- The concurrency contract (concurrent updates)
+- Making concurrent producers safe (`Synchronize`, `ObserveOn`)
+- Thread-safe state: `SynchronizedReactiveProperty`
+- Re-entrancy
+- `TimeProvider` (wall-clock scheduling)
+- `FrameProvider` (frame-clock scheduling) — and when it's necessary
+- Deterministic testing with fake providers
+
+---
+
+## The concurrency contract (concurrent updates)
+
+**R3 does not serialize concurrent producers.** It inherits the Rx grammar: a source must not
+call `OnNext` concurrently or re-entrantly across threads. Operators such as `Where`, `Select`,
+and `Subject<T>` are **not internally locked** — they assume notifications arrive one at a time.
+
+This is a deliberate performance choice, and it bites if you ignore it. Pushing `OnNext` from
+many threads into a stateful downstream corrupts state. Verified: 20,000 concurrent `OnNext`
+calls through a `Where`/`Select` chain into a `List<T>` subscriber, run three times:
+
+```csharp
+var subject = new Subject<int>();
+var list = new List<int>();
+int count = 0;
+subject.Where(x => x % 2 == 0).Select(x => x).Subscribe(x => { list.Add(x); Interlocked.Increment(ref count); });
+Parallel.For(0, 20000, i => subject.OnNext(i));     // concurrent producers
+```
+```text
+trial 1: Interlocked count=9999,  list.Count=9013   (expected 10000)
+trial 2: Interlocked count=10000, list.Count=4104   (expected 10000)
+trial 3: Interlocked count=10000, list.Count=7896   (expected 10000)
+# plus: ArgumentOutOfRangeException thrown inside List.AddWithResize, surfaced via
+# R3's GLOBAL unhandled-exception handler (not the Parallel.For caller)
+```
+
+The `List<T>` is torn (lost items), and the exception from the corrupted add did **not** reach
+the caller — it went to R3's unhandled-exception handler. The lesson: R3 will not protect you
+from a multi-threaded producer.
+
+## Making concurrent producers safe
+
+Put the serialization boundary in the pipeline explicitly.
+
+**`Synchronize()`** wraps delivery in a gate lock so the downstream sees single-threaded
+notifications. Same test, with `Synchronize()` after the source (verified safe across trials):
+
+```csharp
+subject.Synchronize()              // optional: Synchronize(gate) to share a lock object
+       .Where(x => x % 2 == 0)
+       .Subscribe(list.Add);
+Parallel.For(0, 20000, i => subject.OnNext(i));
+```
+```text
+trial 1: list.Count=10000   trial 2: list.Count=10000   trial 3: list.Count=10000
+```
+
+**`ObserveOn*`** also serializes, because it hands every notification to a single target context
+or queue:
+
+```csharp
+source.ObserveOnThreadPool().Subscribe(Handle);                 // deliver on the thread pool
+source.ObserveOnCurrentSynchronizationContext().Subscribe(...); // deliver on the captured ctx (UI)
+```
+
+Verified that `ObserveOnThreadPool()` moves the callback off the producer thread (producer
+thread `5` → observer thread `7`). Platform packages add `ObserveOnDispatcher` (WPF/Avalonia),
+`ObserveOnMainThread` (Unity), etc.
+
+**Rule:** if more than one thread can publish into a stream, add `Synchronize()` (or an
+`ObserveOn*`) immediately after the source. `Subscribe` / `Dispose` happening concurrently *with*
+delivery is handled by R3 (disposal is interlocked); it's concurrent **`OnNext`** that you own.
+
+## Thread-safe state: `SynchronizedReactiveProperty`
+
+`ReactiveProperty<T>` is not safe for concurrent writes. Use `SynchronizedReactiveProperty<T>`
+when many threads assign `.Value`. Verified under 50,000 concurrent writes:
+
+```csharp
+var plain = new ReactiveProperty<int>(0);
+Parallel.For(0, 50000, i => plain.Value = i);
+// no crash, but notification count and final value are racy/non-deterministic
+
+var safe = new SynchronizedReactiveProperty<int>(0);
+Parallel.For(0, 50000, i => safe.Value = i);
+// no exception; internal state stays consistent (final value is still last-writer-wins)
+```
+
+`SynchronizedReactiveProperty` protects the property's internal state; it does not make
+"read-modify-write" sequences atomic — the final value is whichever thread wrote last.
+
+## Re-entrancy
+
+Emitting from inside an observer's own handler is handled gracefully (verified — no stack
+overflow, no reordering surprise for the simple case):
+
+```csharp
+subject.Subscribe(x =>
+{
+    order.Add(x);
+    if (x == 1) subject.OnNext(2);   // re-entrant emit
+});
+subject.OnNext(1);                   // delivery order: [1, 2]
+```
+
+## `TimeProvider` (wall-clock scheduling)
+
+Time-based operators take a `TimeProvider` (the .NET 8 BCL abstraction), defaulting to
+`TimeProvider.System`. Pass an explicit one so the pipeline is testable:
+
+```csharp
+source.Debounce(TimeSpan.FromMilliseconds(300), timeProvider);
+source.Delay(TimeSpan.FromSeconds(1), timeProvider);
+Observable.Interval(TimeSpan.FromSeconds(5), timeProvider);
+Observable.Timer(TimeSpan.FromSeconds(5), timeProvider);
+source.Timeout(TimeSpan.FromSeconds(30), timeProvider);
+```
+
+Use `TimeProvider` for essentially all server/business scheduling — anything measured in elapsed
+real time.
+
+## `FrameProvider` (frame-clock scheduling)
+
+`FrameProvider` is R3's second clock: it counts **frames** (update/render ticks) instead of
+time. Frame operators mirror the time ones — `EveryUpdate`, `DelayFrame(n)`, `IntervalFrame(n)`,
+`DebounceFrame(n)`, `NextFrame`, `TimerFrame`, etc.
+
+```csharp
+Observable.EveryUpdate(frameProvider).Subscribe(_ => Tick());   // once per frame
+source.DelayFrame(2, frameProvider).Subscribe(...);             // shift by 2 frames
+Observable.IntervalFrame(2, frameProvider).Subscribe(...);      // every 2 frames
+```
+
+**When is a `FrameProvider` necessary?** When "progress" is a render/update tick, not elapsed
+time:
+- **Game engines** (Unity, Godot, Stride, MonoGame): ticking on the engine update loop keeps
+  logic in lockstep with rendering and respects pause / time-scale (a wall-clock timer keeps
+  running while the game is paused; a frame clock does not).
+- **UI render loops** (WPF/Avalonia/WinUI composition frames): react per frame for animation or
+  per-frame recomputation.
+- **Deterministic frame-stepping in tests** (below).
+
+Plain server/business code does **not** need a `FrameProvider` — use `TimeProvider`. Each host
+supplies its own provider (`UnityFrameProvider`, `WpfRenderingFrameProvider`, …); R3 sets the
+default via the platform package's initializer.
+
+## Deterministic testing with fake providers
+
+Both clocks have fakes, so time- and frame-dependent pipelines test instantly with zero real
+waiting.
+
+**`FakeTimeProvider`** (from `Microsoft.Extensions.TimeProvider.Testing`) + `ToLiveList()`
+(verified — a 5-second timer fires only after advancing a full 5 seconds of virtual time):
+
+```csharp
+var fake = new FakeTimeProvider();
+using var live = Observable.Timer(TimeSpan.FromSeconds(5), fake).ToLiveList();
+
+fake.Advance(TimeSpan.FromSeconds(4));
+Assert.False(live.IsCompleted);          // not yet
+
+fake.Advance(TimeSpan.FromSeconds(1));    // total 5s
+Assert.True(live.IsCompleted);            // fired; no real time elapsed
+```
+
+**`FakeFrameProvider`** (ships in R3) — drive frames by hand (verified):
+
+```csharp
+var frame = new FakeFrameProvider();
+using var live = Observable.EveryUpdate(frame)
+    .Select(_ => frame.GetFrameCount())
+    .ToLiveList();
+
+frame.Advance();    // 1 frame
+frame.Advance(3);   // 3 more frames
+// live now contains one entry per advanced frame
+```
+
+`ToLiveList()` is R3's test sink: it captures emissions into a list you can assert on, and
+exposes `IsCompleted`. Combined with fake providers it makes Rx pipelines — historically painful
+to test because of real timers — fully deterministic.


### PR DESCRIPTION
## Summary

Adds a new progressive-disclosure skill for [Cysharp's R3](https://github.com/Cysharp/R3) — the modern reimplementation of Reactive Extensions for .NET.

```
skills/r3-reactive-extensions/
├── SKILL.md                          # why/when, Observable<T>/Observer<T> model, quick-start, nav, links
├── rx-net-differences.md             # differences vs System.Reactive (Rx.NET) + migration checklist
├── async-and-integration-patterns.md # AwaitOperation async dispatch, Task & IAsyncEnumerable, MVVM, lifecycle
└── scheduling-and-concurrency.md      # concurrent-update contract, TimeProvider vs FrameProvider, testing
```

## What it covers

- **Why R3 / when to use it** — the `OnErrorResume` error contract (errors don't kill subscriptions), `TimeProvider`/`FrameProvider` instead of `IScheduler`, subscription-leak tracking, cross-platform reach.
- **R3 vs Reactive Extensions** — abstract-class core types, the `Result`-based completion model, operator renames (`Throttle`→`Debounce`, `Sample`→`ThrottleLast`, `Buffer`→`Chunk`), dropped/`*Async`-only APIs, the scheduler swap, and a 10-step migration checklist.
- **Common patterns** — async dispatch via the `AwaitOperation` enum (`Sequential`/`Drop`/`Switch`/`Parallel`/…), `Task` integration, `IAsyncEnumerable` round-tripping, `ReactiveProperty`/`BindableReactiveProperty` for MVVM, and subscription lifecycle.
- **Concurrent updates** — R3 inherits the Rx serialization contract (operators are not internally locked); documents `Synchronize()`, `ObserveOn*`, and `SynchronizedReactiveProperty` with a reproduced data race.
- **TimeProvider vs FrameProvider** — when each is necessary, and deterministic testing with `FakeTimeProvider` / `FakeFrameProvider`.

## Verification

Every behavioral and API claim was verified against **R3 1.3.1** with runnable proofs of concept (reflection of the real API surface plus runtime POCs for the error model, async-dispatch interleavings, Task/`IAsyncEnumerable` bridges, the concurrency races, and time/frame virtualization). Captured output is included in the reference files as evidence.

## Repo wiring

- Registered in `.claude-plugin/plugin.json`
- Routed the `r3-*` prefix in `scripts/generate-skill-index-snippets.sh`
- Updated the README skill index and tables
- `./scripts/validate-marketplace.sh` passes (35 skills registered)

## Progressive-disclosure compliance

- SKILL.md body well under the 500-line target
- Each sibling has a table of contents
- One-level-deep references (SKILL.md → siblings only)
- Forward slashes throughout; frontmatter matches house style