### PR TITLE
Overhaul otel skill with latest updates

### DIFF
--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -233,7 +233,11 @@ catch (Exception ex)
         {
             ["exception.type"] = ex.GetType().FullName,
             ["exception.message"] = ex.Message,
-            ["exception.stacktrace"] = ex.ToString()
+            // exception.stacktrace is Recommended per OTel spec, but can be large.
+            // Consider logging the full stack trace via ILogger instead and relying
+            // on trace-log correlation. The spec is moving toward log-based
+            // exception recording (OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN).
+            // ["exception.stacktrace"] = ex.ToString()
         }));
     }
     throw;
@@ -244,6 +248,7 @@ catch (Exception ex)
 - Set `ActivityStatusCode.Ok` on success, `ActivityStatusCode.Error` on exception
 - Use `SetStatus` (the SDK translates it to OTel span status) — legacy `otel.status_code`/`otel.status_description` tags are no longer needed
 - Record exception events per [OTel conventions](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions_attributes/)
+- `exception.stacktrace` is **Recommended** by the spec but can bloat spans. Prefer logging the full stack trace via `ILogger` and relying on trace-log correlation. The OTel spec is moving toward log-based exception recording (`OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN`).
 
 ### Activity Events
 

--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -191,12 +191,15 @@ Choose the correct `ActivityKind` to clarify the span's role in distributed trac
 ### Span Attributes (Tags)
 
 ```csharp
-// ✅ Namespace prefix, lowercase, underscore-delimited
+// ✅ Application code: use your own namespace
 activity?.SetTag("myapp.order_id", orderId);
-activity?.SetTag("myapp.db.table_name", tableName);
-// Use standard semantic conventions where applicable
-activity?.SetTag("db.system", "postgresql");
-activity?.SetTag("http.request.method", "GET");
+activity?.SetTag("myapp.payment.status", "confirmed");
+
+// ✅ Infrastructure/library code: use semantic conventions
+// (e.g., custom database client, custom transport, custom messaging library)
+// activity?.SetTag("db.system", "postgresql");
+// activity?.SetTag("http.request.method", "GET");
+
 // Values can be strings, numbers, booleans, or homogeneous arrays
 activity?.SetTag("app.item_count", 42);
 activity?.SetTag("app.related_ids", new int[] { 1, 2, 3 });
@@ -210,7 +213,8 @@ activity?.SetTag("myapp.order-id", orderId);    // ❌ Wrong delimiter
 - Namespace prefix matching your component: `myapp.*`, `myapp.db.*`
 - All lowercase, underscore (`_`) delimiters, singular form
 - Attribute values: string, boolean, double, int64, byte arrays, homogeneous arrays (null/empty valid per [AnyValue spec](https://opentelemetry.io/docs/specs/otel/common/#anyvalue))
-- Prefer [semantic conventions](https://opentelemetry.io/docs/specs/semconv/) over custom; only set if no downstream library will
+- **Application code**: use your own namespace (`myapp.*`). Do not set infrastructure-level conventions (`db.system`, `http.request.method`, `messaging.*`) — those are already handled by the OTel instrumentation libraries.
+- **Library/infrastructure code**: use [semantic conventions](https://opentelemetry.io/docs/specs/semconv/) when implementing the concept the convention describes (e.g., a custom database client sets `db.system`). Do not use OTel namespaces as a prefix for custom attributes.
 
 ### Activity Status and Errors
 

--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -148,7 +148,7 @@ async Task HelperAsync()
 - Always null-check Activity after creation (listener may filter or sample it out)
 - Never start activities in async helper methods (`Activity.Current` uses `AsyncLocal`)
 - Guard expensive tag computation behind `activity.IsAllDataRequested`
-- Always use W3C ID format (default in .NET Core 3.0+ / .NET 5+; on .NET Framework, set `Activity.DefaultIdFormat = ActivityIdFormat.W3C` and `Activity.ForceDefaultIdFormat = true` if the parent uses Hierarchical)
+- Use W3C TraceContext. .NET Core 3.0+ / .NET 5+ uses it by default; older TFMs or .NET Framework apps may set `Activity.DefaultIdFormat = ActivityIdFormat.W3C` at startup and use `Activity.ForceDefaultIdFormat = true` to override hierarchical parents.
 
 ### Activity Naming
 
@@ -195,10 +195,9 @@ Choose the correct `ActivityKind` to clarify the span's role in distributed trac
 activity?.SetTag("myapp.order_id", orderId);
 activity?.SetTag("myapp.payment.status", "confirmed");
 
-// ✅ Infrastructure/library code: use semantic conventions
-// (e.g., custom database client, custom transport, custom messaging library)
-// activity?.SetTag("db.system", "postgresql");
-// activity?.SetTag("http.request.method", "GET");
+// ✅ Manual infrastructure instrumentation: use semantic conventions
+// activity?.SetTag("db.system.name", "postgresql"); // custom database client
+// activity?.SetTag("http.request.method", "GET"); // custom HTTP transport
 
 // Values can be strings, numbers, booleans, or homogeneous arrays
 activity?.SetTag("app.item_count", 42);
@@ -213,8 +212,8 @@ activity?.SetTag("myapp.order-id", orderId);    // ❌ Wrong delimiter
 - Namespace prefix matching your component: `myapp.*`, `myapp.db.*`
 - All lowercase, underscore (`_`) delimiters, singular form
 - Attribute values: string, boolean, double, int64, byte arrays, homogeneous arrays (null/empty valid per [AnyValue spec](https://opentelemetry.io/docs/specs/otel/common/#anyvalue))
-- **Application code**: use your own namespace (`myapp.*`). Do not set infrastructure-level conventions (`db.system`, `http.request.method`, `messaging.*`) — those are already handled by the OTel instrumentation libraries.
-- **Library/infrastructure code**: use [semantic conventions](https://opentelemetry.io/docs/specs/semconv/) when implementing the concept the convention describes (e.g., a custom database client sets `db.system`). Do not use OTel namespaces as a prefix for custom attributes.
+- **Business/domain attributes**: use your own namespace (`myapp.*`).
+- **HTTP, database, messaging, or RPC concepts you manually instrument**: use [semantic conventions](https://opentelemetry.io/docs/specs/semconv/). Do not duplicate attributes already emitted by auto-instrumentation. Do not use OTel namespaces as prefixes for custom attributes.
 
 ### Activity Status and Errors
 
@@ -233,11 +232,8 @@ catch (Exception ex)
         {
             ["exception.type"] = ex.GetType().FullName,
             ["exception.message"] = ex.Message,
-            // exception.stacktrace is Recommended per OTel spec, but can be large.
-            // Consider logging the full stack trace via ILogger instead and relying
-            // on trace-log correlation. The spec is moving toward log-based
-            // exception recording (OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN).
-            // ["exception.stacktrace"] = ex.ToString()
+            // Include unless size/sensitivity/volume policy says otherwise.
+            // ["exception.stacktrace"] = ex.ToString() // Recommended
         }));
     }
     throw;
@@ -247,43 +243,28 @@ catch (Exception ex)
 **Rules**:
 - Set `ActivityStatusCode.Ok` on success, `ActivityStatusCode.Error` on exception
 - Use `SetStatus` (the SDK translates it to OTel span status) — legacy `otel.status_code`/`otel.status_description` tags are no longer needed
-- Record exception events per [OTel conventions](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions_attributes/)
-- `exception.stacktrace` is **Recommended** by the spec but can bloat spans. Prefer logging the full stack trace via `ILogger` and relying on trace-log correlation. The OTel spec is moving toward log-based exception recording (`OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN`).
+- Record exception events per [OTel exception span conventions](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/)
+- `exception.stacktrace` is **Recommended** for exception span events. Include it unless size, sensitivity, or volume policy says otherwise. For high-volume handled exceptions, prefer `ILogger` with trace correlation or the semconv logs opt-in (`OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN`).
 
 ### Activity Events
 
 ```csharp
-// ✅ Use events for additional context (sparingly — stored in-memory until export)
+// ✅ Use events sparingly — stored in-memory until export
 activity?.AddEvent(new ActivityEvent("ItemRetried", tags: new ActivityTagsCollection
 {
     ["retry_attempt"] = retryCount
 }));
-
 // ❌ Don't use events for verbose logging — use ILogger instead
 ```
 
 ### Accessing Activities
 
 ```csharp
-// ❌ WRONG: Activity.Current can be "overloaded" by user code creating
-// their own ambient spans. You might end up tagging a span you don't own.
-var activity = Activity.Current;
-
-// ✅ CORRECT: Capture the activity reference when you create it and use
-// it directly. Don't rely on Activity.Current for spans you own.
-using var activity = ActivitySource.StartActivity("MyOperation");
-// ... later, use the captured reference:
-activity?.SetTag("myapp.key", value);
-
-// If your framework manages its own context bag (e.g., Akka.NET actors),
-// store the activity there and restore it when needed:
-// context.Store(activity);
-// ... later:
-// var activity = context.Retrieve<Activity>();
-// activity?.SetTag("myapp.key", value);
+var current = Activity.Current; // ❌ may be a user-created ambient span
+using var ownedActivity = ActivitySource.StartActivity("MyOperation"); // ✅ captured reference
+ownedActivity?.SetTag("myapp.key", value);
 ```
-
-**Why**: `Activity.Current` uses `AsyncLocal`, which flows across `await` points. If user code between your `StartActivity` and your tag-setting code creates its own activity, `Activity.Current` points to theirs, not yours. Always use the reference you captured.
+**Rules**: Do not rely on `Activity.Current` for spans you own; user code can replace it via `AsyncLocal`. Pass/store captured `Activity` only while alive. Store `ActivityContext` for propagation identity.
 
 ### Span Links
 
@@ -350,9 +331,7 @@ public sealed class OrderProcessingMetrics : IDisposable
 | **ObservableGauge** | `CreateObservableGauge<T>` | Async callback, non-monotonic | CPU/memory usage |
 | **ObservableUpDownCounter** | `CreateObservableUpDownCounter<T>` | Async callback, bi-directional | Active tasks by priority |
 
-See [metrics-and-instruments-reference.md](metrics-and-instruments-reference.md) for
-full creation and recording examples for every instrument type, including callback
-patterns for observable instruments.
+See [metrics-and-instruments-reference.md](metrics-and-instruments-reference.md) for full creation/recording examples and observable callback patterns.
 
 ### Metric Recording Method Naming
 

--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -82,8 +82,7 @@ For SDK setup, resource configuration, exporters, sampling, and logs integration
 
 ### Resiliency First
 **CRITICAL**: Exceptions in diagnostic/tracing/metrics logic MUST NEVER impact application processing.
-- Always protect against null Activity references except in Activity extension methods (use `activity?.ExtensionMethod()`)
-- Assume Activity instances can be null (only created when listeners subscribe)
+- Assume Activity instances can be null. Always protect against null Activity references except in Activity extension methods (use `activity?.ExtensionMethod()`)
 - Guard all instrumentation code with appropriate null checks
 
 ### API Surface Awareness
@@ -118,7 +117,7 @@ public class MyFeature
 - Every component defines a primary `ActivitySource` for mainstream activities
 - Name typically matches the component or NuGet package (e.g., `"MyCompany.MyLibrary"`)
 - Version the ActivitySource using SemVer
-- Create separate ActivitySources for specialized/opt-in scenarios
+- Create separate ActivitySources for specialized/opt-in scenarios (use activity namespace hierarchies to allow users to filter out information)
 
 ### Creating Activities
 

--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -145,7 +145,7 @@ async Task HelperAsync()
 
 **Rules**:
 - Check `ActivitySource.HasListeners()` before creating (zero-allocation fast path)
-- Always null-check Activity after creation (listeners may not be subscribed)
+- Always null-check Activity after creation (listener may filter or sample it out)
 - Never start activities in async helper methods (`Activity.Current` uses `AsyncLocal`)
 - Guard expensive tag computation behind `activity.IsAllDataRequested`
 - Always use W3C ID format

--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -25,10 +25,8 @@ tags:
 
 ## Architecture: .NET Is Different
 
-**CRITICAL**: The .NET OpenTelemetry implementation is fundamentally different from other
-platforms. .NET provides tracing, metrics, and logging APIs **in the framework itself**.
-That means **OTel does not provide a separate instrumentation API** — it uses the built-in
-.NET APIs and acts as the collection/export layer.
+**CRITICAL**: The .NET OpenTelemetry implementation is fundamentally different from other platforms. .NET provides tracing, metrics, and logging APIs **in the framework itself**.
+That means **OTel does not provide a separate instrumentation API** — it uses the built-in .NET APIs and acts as the collection/export layer.
 
 ### The Three Built-in .NET APIs (Primary — Zero Dependencies)
 
@@ -69,14 +67,11 @@ composition root (not in libraries):
 **Library authors**: Add **nothing**. Use only `System.Diagnostics.*` and `ILogger`.
 The consuming application wires up the SDK and exporters.
 
-**Application authors**: Add `OpenTelemetry.Extensions.Hosting` + the exporters and
-instrumentation libraries you need. See [sdk-resources-and-logs-reference.md](sdk-resources-and-logs-reference.md)
-for full setup patterns.
+**Application authors**: Add `OpenTelemetry.Extensions.Hosting` + the exporters and instrumentation libraries you need. See [sdk-resources-and-logs-reference.md](sdk-resources-and-logs-reference.md) for full setup patterns.
 
 **Never add** `OpenTelemetry.Api` to a library — `System.Diagnostics.*` IS the API.
 
-For SDK setup, resource configuration, exporters, sampling, and logs integration, see
-[sdk-resources-and-logs-reference.md](sdk-resources-and-logs-reference.md).
+For SDK setup, resource configuration, exporters, sampling, and logs integration, see [sdk-resources-and-logs-reference.md](sdk-resources-and-logs-reference.md).
 
 ## Core Principles
 
@@ -268,8 +263,7 @@ ownedActivity?.SetTag("myapp.key", value);
 
 ### Span Links
 
-Links connect a span to other spans that are causally related but not in a direct
-parent-child relationship — batch processing, scatter/gather, trace boundary crossings.
+Links connect a span to other spans that are causally related but not in a direct parent-child relationship — batch processing, scatter/gather, trace boundary crossings.
 
 ```csharp
 var links = new List<ActivityLink>
@@ -282,18 +276,13 @@ var activity = ActivitySource.StartActivity(
     ActivityKind.Internal, name: "batch-process", links: links);
 ```
 
-See [traces-and-propagation-reference.md](traces-and-propagation-reference.md) for full
-link patterns including batch processing, scatter/gather, and trace boundary crossing.
+See [traces-and-propagation-reference.md](traces-and-propagation-reference.md) for full link patterns including batch processing, scatter/gather, and trace boundary crossing.
 
 ### Context Propagation
 
-Distributed tracing requires propagating trace context across process boundaries
-(HTTP calls, message queues, etc.) using W3C `traceparent` headers. In .NET this is
-handled by `DistributedContextPropagator`. The OTel SDK configures W3C TraceContext
-propagation by default.
+Distributed tracing requires propagating trace context across process boundaries (HTTP calls, message queues, etc.) using W3C `traceparent` headers. In .NET, this is handled by `DistributedContextPropagator`. The OTel SDK configures W3C TraceContext propagation by default.
 
-See [traces-and-propagation-reference.md](traces-and-propagation-reference.md) for
-propagation patterns, custom propagators, and manual inject/extract for non-standard transports.
+See [traces-and-propagation-reference.md](traces-and-propagation-reference.md) for propagation patterns, custom propagators, and manual inject/extract for non-standard transports.
 
 ## Metrics
 
@@ -468,9 +457,7 @@ private readonly Meter meter = new("MyApp.MyComponent", "0.8.0");
 
 ## Logs
 
-.NET logs integrate with OpenTelemetry through the built-in `ILogger` API. The OTel
-SDK provides `AddOpenTelemetry()` on the logging builder to collect, process, and export
-logs. Log records are automatically correlated with traces via `TraceId`/`SpanId`.
+.NET logs integrate with OpenTelemetry through the built-in `ILogger` API. The OTel SDK provides `AddOpenTelemetry()` on the logging builder to collect, process, and export logs. Log records are automatically correlated with traces via `TraceId`/`SpanId`.
 
 See [sdk-resources-and-logs-reference.md](sdk-resources-and-logs-reference.md) for
 full logs integration patterns including correlation, redaction, structured logging,

--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -148,7 +148,7 @@ async Task HelperAsync()
 - Always null-check Activity after creation (listener may filter or sample it out)
 - Never start activities in async helper methods (`Activity.Current` uses `AsyncLocal`)
 - Guard expensive tag computation behind `activity.IsAllDataRequested`
-- Always use W3C ID format
+- Always use W3C ID format (default in .NET Core 3.0+ / .NET 5+; on .NET Framework, set `Activity.DefaultIdFormat = ActivityIdFormat.W3C` and `Activity.ForceDefaultIdFormat = true` if the parent uses Hierarchical)
 
 ### Activity Naming
 

--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -178,10 +178,10 @@ Choose the correct `ActivityKind` to clarify the span's role in distributed trac
 | `ActivityKind` | OTel SpanKind | When to use |
 |----------------|---------------|-------------|
 | `Internal` | `INTERNAL` | Default — in-process operations not crossing a remote boundary |
-| `Server` | `SERVER` | Processing an incoming request (HTTP server, gRPC server, message consumer) |
-| `Client` | `CLIENT` | Making an outgoing request (HTTP client, database client, RPC call) |
-| `Producer` | `PRODUCER` | Sending a deferred/asynchronous message (message queue publish, job enqueue) |
-| `Consumer` | `CONSUMER` | Receiving a deferred/asynchronous message (message queue consume, job dequeue) |
+| `Server` | `SERVER` | Processing an incoming request/response call (HTTP server, gRPC server, RPC server) |
+| `Client` | `CLIENT` | Making an outgoing request/response call (HTTP client, database client, RPC call) |
+| `Producer` | `PRODUCER` | Enqueuing/publishing deferred work (message queue publish, event emit, job enqueue) |
+| `Consumer` | `CONSUMER` | Dequeuing/processing deferred work (message queue receive, event handle, job dequeue) |
 
 **Rules**:
 - A single span SHOULD NOT serve more than one purpose

--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -185,7 +185,7 @@ Choose the correct `ActivityKind` to clarify the span's role in distributed trac
 
 **Rules**:
 - A single span SHOULD NOT serve more than one purpose
-- Create a new span before injecting `SpanContext` for a remote outgoing call
+- Create the outgoing span **before** injecting its `SpanContext` into the request. If you inject first, the parent's context propagates instead and the outgoing span ends up dangling (no connection to the downstream call).
 - See [traces-and-propagation-reference.md](traces-and-propagation-reference.md) for detailed SpanKind guidance with examples
 
 ### Span Attributes (Tags)

--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -117,7 +117,7 @@ public class MyFeature
 - Every component defines a primary `ActivitySource` for mainstream activities
 - Name typically matches the component or NuGet package (e.g., `"MyCompany.MyLibrary"`)
 - Version the ActivitySource using SemVer
-- Create separate ActivitySources for specialized/opt-in scenarios (use activity namespace hierarchies to allow users to filter out information)
+- Create separate `ActivitySource`s for specialized or opt-in scenarios. Use hierarchical source names, e.g. `MyCompany.MyLibrary` and `MyCompany.MyLibrary.Detailed`, so consuming applications can subscribe only to the sources they want via `AddSource(...)` and backends can filter by instrumentation scope.
 
 ### Creating Activities
 

--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -265,12 +265,25 @@ activity?.AddEvent(new ActivityEvent("ItemRetried", tags: new ActivityTagsCollec
 ### Accessing Activities
 
 ```csharp
-// ❌ WRONG: Activity.Current might be a user-created span, not yours
+// ❌ WRONG: Activity.Current can be "overloaded" by user code creating
+// their own ambient spans. You might end up tagging a span you don't own.
 var activity = Activity.Current;
 
-// ✅ CORRECT: Pass Activity explicitly or via a dedicated context object
-if (context.TryGetActivity(out var activity)) { activity?.SetTag("custom", "value"); }
+// ✅ CORRECT: Capture the activity reference when you create it and use
+// it directly. Don't rely on Activity.Current for spans you own.
+using var activity = ActivitySource.StartActivity("MyOperation");
+// ... later, use the captured reference:
+activity?.SetTag("myapp.key", value);
+
+// If your framework manages its own context bag (e.g., Akka.NET actors),
+// store the activity there and restore it when needed:
+// context.Store(activity);
+// ... later:
+// var activity = context.Retrieve<Activity>();
+// activity?.SetTag("myapp.key", value);
 ```
+
+**Why**: `Activity.Current` uses `AsyncLocal`, which flows across `await` points. If user code between your `StartActivity` and your tag-setting code creates its own activity, `Activity.Current` points to theirs, not yours. Always use the reference you captured.
 
 ### Span Links
 

--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -1,32 +1,82 @@
 ---
-name: OpenTelemetry-NET-Instrumentation
-description: Provides guidance for implementing OpenTelemetry instrumentation in .NET codebases, covering tracing (Activities/Spans), metrics, naming conventions, error handling, performance, and API design best practices.
-version: 1.0.0
+name: opentelemetry-net-instrumentation
+description: Provides guidance for implementing OpenTelemetry instrumentation in .NET codebases, covering tracing (Activities/Spans), metrics, logs, naming conventions, error handling, performance, SDK setup, resources, context propagation, and API design best practices.
+version: 2.0.0
 tags:
   - opentelemetry
   - dotnet
   - observability
   - tracing
   - metrics
+  - logs
   - performance
 ---
 
 # OpenTelemetry .NET Instrumentation Skill
 
-## Description
-Provides guidance for implementing OpenTelemetry instrumentation in .NET codebases, covering tracing (Activities/Spans), metrics, naming conventions, error handling, performance, and API design best practices.
-
 ## When to Use
-- Adding OpenTelemetry instrumentation to .NET code
-- Creating or modifying ActivitySources and metrics
-- Reviewing telemetry implementations for compliance
+- Adding OpenTelemetry instrumentation to .NET code (traces, metrics, logs)
+- Creating or modifying ActivitySources, Meters, or ILogger usage
+- Setting up the OpenTelemetry SDK, resources, exporters, or sampling
+- Reviewing telemetry implementations for spec compliance
 - Optimizing instrumentation performance
 - Designing telemetry APIs that become part of the public surface
+- Implementing context propagation across service boundaries
 
-## Prerequisites
-- .NET application with OpenTelemetry SDK
-- Understanding of System.Diagnostics.Metrics and ActivitySource APIs
-- Access to observability backend (e.g., Jaeger, Prometheus, Grafana)
+## Architecture: .NET Is Different
+
+**CRITICAL**: The .NET OpenTelemetry implementation is fundamentally different from other
+platforms. .NET provides tracing, metrics, and logging APIs **in the framework itself**.
+That means **OTel does not provide a separate instrumentation API** — it uses the built-in
+.NET APIs and acts as the collection/export layer.
+
+### The Three Built-in .NET APIs (Primary — Zero Dependencies)
+
+| Signal | .NET Framework API | Namespace |
+|--------|-------------------|-----------|
+| **Tracing** | `ActivitySource` / `Activity` | `System.Diagnostics` |
+| **Metrics** | `Meter` / `Counter<T>` / `Histogram<T>` / etc. | `System.Diagnostics.Metrics` |
+| **Logging** | `ILogger<T>` | `Microsoft.Extensions.Logging` |
+
+These are **the primary and only APIs** library authors should use for instrumentation.
+They ship with the .NET runtime — **no NuGet packages required**.
+
+### The OTel Collection/Export Layer (Secondary — Application Root Only)
+
+OTel NuGet packages are the **collection and export layer**, added only at the application
+composition root (not in libraries):
+
+| Package | Purpose | When to add |
+|---------|---------|-------------|
+| `OpenTelemetry.Extensions.Hosting` | DI integration for ASP.NET Core / generic host | Application only |
+| `OpenTelemetry.Exporter.Console` | Console exporter (dev/testing) | Application only |
+| `OpenTelemetry.Exporter.OpenTelemetryProtocol` | OTLP exporter (production) | Application only |
+| `OpenTelemetry.Exporter.Prometheus*` | Prometheus metrics endpoint | Application only |
+| `OpenTelemetry.Instrumentation.AspNetCore` | Auto-instrument ASP.NET Core requests | Application only |
+| `OpenTelemetry.Instrumentation.Http` | Auto-instrument HttpClient calls | Application only |
+| `OpenTelemetry.Instrumentation.SqlClient` | Auto-instrument SQL calls | Application only |
+
+### Package Decision Guide
+
+**Before adding ANY OpenTelemetry NuGet package, discuss the trade-off with the user:**
+
+> "You're about to add an OTel NuGet package. Is this an application where you need to
+> export telemetry to an observability backend (Jaeger, Prometheus, OTLP collector)?
+> If you're writing a library, you likely need **zero** OTel packages — just use
+> `System.Diagnostics.ActivitySource` / `System.Diagnostics.Metrics.Meter` and let the
+> consuming application configure the export pipeline. Do you want to proceed?"
+
+**Library authors**: Add **nothing**. Use only `System.Diagnostics.*` and `ILogger`.
+The consuming application wires up the SDK and exporters.
+
+**Application authors**: Add `OpenTelemetry.Extensions.Hosting` + the exporters and
+instrumentation libraries you need. See [sdk-resources-and-logs-reference.md](sdk-resources-and-logs-reference.md)
+for full setup patterns.
+
+**Never add** `OpenTelemetry.Api` to a library — `System.Diagnostics.*` IS the API.
+
+For SDK setup, resource configuration, exporters, sampling, and logs integration, see
+[sdk-resources-and-logs-reference.md](sdk-resources-and-logs-reference.md).
 
 ## Core Principles
 
@@ -43,9 +93,10 @@ Provides guidance for implementing OpenTelemetry instrumentation in .NET codebas
 - Exception: High-cardinality metric dimensions may require explicit opt-in
 
 ### Standards Compliance
-- Follow Microsoft best practices for [distributed tracing instrumentation](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing-instrumentation-walkthroughs)
-- Follow [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/)
-- All attributes must be non-null, non-empty strings
+- Follow Microsoft best practices for [distributed tracing instrumentation](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing-instrumentation-walkthroughs)
+- Follow [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/)
+- Attribute values support: **string, boolean, double (IEEE 754), int64, byte arrays, and homogeneous arrays** of these primitive types. Null/empty values are valid and meaningful per the [OTel AnyValue spec](https://opentelemetry.io/docs/specs/otel/common/#anyvalue) — they MUST be stored and passed to exporters.
+- Attribute **keys** must be non-null, non-empty strings
 
 ## Traces / Spans (Activities)
 
@@ -72,51 +123,47 @@ public class MyFeature
 ### Creating Activities
 
 ```csharp
-// ✅ CORRECT: Check HasListeners before creating
+// ✅ Check HasListeners, null-check, then guard expensive work behind IsAllDataRequested
 if (ActivitySource.HasListeners())
 {
     using var activity = ActivitySource.StartActivity("ProcessItem", ActivityKind.Internal);
-
-    if (activity != null)
+    if (activity != null && activity.IsAllDataRequested)
     {
         activity.DisplayName = "Processing order #12345";
-
-        // Only compute expensive tags if requested
-        if (activity.IsAllDataRequested)
-        {
-            activity.SetTag("app.item_id", itemId);
-            activity.SetTag("app.item_type", itemType);
-        }
+        activity.SetTag("app.item_id", itemId);
+        activity.SetTag("app.item_type", itemType);
     }
 }
 
-// ❌ WRONG: Don't start activities in async helper methods (breaks AsyncLocal)
+// ❌ WRONG: Don't start activities in fire-and-forget tasks where the
+// using scope ends before the async work completes (AsyncLocal context is lost)
 async Task HelperAsync()
 {
-    using var activity = ActivitySource.StartActivity("Helper"); // ❌ BAD
-    await DoWorkAsync();
+    using var activity = ActivitySource.StartActivity("Helper");
+    _ = Task.Run(() => DoWorkAsync()); // ❌ activity disposed before task completes
 }
 ```
 
 **Rules**:
 - Check `ActivitySource.HasListeners()` before creating (zero-allocation fast path)
-- Always check if activity is null after creation
-- Never start activities in asynchronous helper methods (`Activity.Current` uses `AsyncLocal`)
-- Use `activity.IsAllDataRequested` before expensive computations
-- Always use W3C ID format (enforce format change if parent uses hierarchical)
+- Always null-check Activity after creation (listeners may not be subscribed)
+- Never start activities in async helper methods (`Activity.Current` uses `AsyncLocal`)
+- Guard expensive tag computation behind `activity.IsAllDataRequested`
+- Always use W3C ID format
 
 ### Activity Naming
 
 ```csharp
-// ✅ CORRECT: Unique operation name, friendly display name
+// ✅ Unique operation name, friendly display name (null-check before accessing)
 using var activity = ActivitySource.StartActivity(
     name: "ProcessItem",              // Unique, identifies class of spans
     kind: ActivityKind.Internal
 );
-activity.DisplayName = "Processing order #12345"; // User-friendly, can be specific
+if (activity != null)
+    activity.DisplayName = "Processing order #12345"; // User-friendly, can be specific
 
 // ❌ WRONG: Don't include runtime data in operation name
-using var activity = ActivitySource.StartActivity($"Process_{itemId}"); // ❌ BAD
+using var badActivity = ActivitySource.StartActivity($"Process_{itemId}"); // ❌
 ```
 
 **Rules**:
@@ -125,38 +172,50 @@ using var activity = ActivitySource.StartActivity($"Process_{itemId}"); // ❌ B
 - Use human-readable `DisplayName` for specifics
 - Follow [OpenTelemetry span naming conventions](https://opentelemetry.io/docs/specs/otel/trace/api/#span)
 
+### SpanKind Selection
+
+Choose the correct `ActivityKind` to clarify the span's role in distributed tracing:
+
+| `ActivityKind` | OTel SpanKind | When to use |
+|----------------|---------------|-------------|
+| `Internal` | `INTERNAL` | Default — in-process operations not crossing a remote boundary |
+| `Server` | `SERVER` | Processing an incoming request (HTTP server, gRPC server, message consumer) |
+| `Client` | `CLIENT` | Making an outgoing request (HTTP client, database client, RPC call) |
+| `Producer` | `PRODUCER` | Sending a deferred/asynchronous message (message queue publish, job enqueue) |
+| `Consumer` | `CONSUMER` | Receiving a deferred/asynchronous message (message queue consume, job dequeue) |
+
+**Rules**:
+- A single span SHOULD NOT serve more than one purpose
+- Create a new span before injecting `SpanContext` for a remote outgoing call
+- See [traces-and-propagation-reference.md](traces-and-propagation-reference.md) for detailed SpanKind guidance with examples
+
 ### Span Attributes (Tags)
 
 ```csharp
-// ✅ CORRECT: Namespace, lowercase, underscore-delimited
+// ✅ Namespace prefix, lowercase, underscore-delimited
 activity?.SetTag("myapp.order_id", orderId);
-activity?.SetTag("myapp.order_type", orderType);
 activity?.SetTag("myapp.db.table_name", tableName);
-
-// Standard semantic conventions where applicable
+// Use standard semantic conventions where applicable
 activity?.SetTag("db.system", "postgresql");
-activity?.SetTag("http.method", "GET");
+activity?.SetTag("http.request.method", "GET");
+// Values can be strings, numbers, booleans, or homogeneous arrays
+activity?.SetTag("app.item_count", 42);
+activity?.SetTag("app.related_ids", new int[] { 1, 2, 3 });
 
-// ❌ WRONG: Various naming violations
-activity?.SetTag("MyApp.OrderId", orderId);         // ❌ Wrong case
-activity?.SetTag("myapp.order-id", orderId);        // ❌ Wrong delimiter
-activity?.SetTag("myapp.orders", count);            // ❌ Plural
-activity?.SetTag("unrelated.ip_address", ip);       // ❌ Not characteristic
+// ❌ WRONG: PascalCase, hyphen delimiter, plural, or unrelated namespace
+activity?.SetTag("MyApp.OrderId", orderId);     // ❌ Wrong case
+activity?.SetTag("myapp.order-id", orderId);    // ❌ Wrong delimiter
 ```
 
-**Naming Conventions**:
-- Use a namespace prefix matching your component: `myapp.*`, `myapp.db.*`
-- All lowercase letters
-- Underscore (`_`) delimiters for multi-word attributes
-- Singular form
-- Only set tags directly relevant to this activity
-- Prefer standard [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/) over custom attributes where they exist
-- Only use standard semantic conventions if certain no downstream library will set them
+**Rules**:
+- Namespace prefix matching your component: `myapp.*`, `myapp.db.*`
+- All lowercase, underscore (`_`) delimiters, singular form
+- Attribute values: string, boolean, double, int64, byte arrays, homogeneous arrays (null/empty valid per [AnyValue spec](https://opentelemetry.io/docs/specs/otel/common/#anyvalue))
+- Prefer [semantic conventions](https://opentelemetry.io/docs/specs/semconv/) over custom; only set if no downstream library will
 
 ### Activity Status and Errors
 
 ```csharp
-// ✅ CORRECT: Set status and record exceptions
 try
 {
     await ProcessItemAsync();
@@ -166,182 +225,151 @@ catch (Exception ex)
 {
     if (activity != null)
     {
-        activity.SetStatus(ActivityStatusCode.Error);
-        activity.SetTag("otel.status_code", "error");
-        activity.SetTag("otel.status_description", ex.Message);
-
-        // Record exception event per OTel spec
-        activity.AddEvent(new ActivityEvent(
-            "exception",
-            tags: new ActivityTagsCollection
-            {
-                ["exception.type"] = ex.GetType().FullName,
-                ["exception.message"] = ex.Message,
-                ["exception.stacktrace"] = ex.ToString()
-            }
-        ));
+        activity.SetStatus(ActivityStatusCode.Error, ex.Message); // modern API
+        activity.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
+        {
+            ["exception.type"] = ex.GetType().FullName,
+            ["exception.message"] = ex.Message,
+            ["exception.stacktrace"] = ex.ToString()
+        }));
     }
     throw;
 }
 ```
 
 **Rules**:
-- Set `ActivityStatusCode.Ok` on success
-- Set `ActivityStatusCode.Error` on exception
-- Always add `otel.status_code` and `otel.status_description` tags
-- Record exception events following [OTel exception conventions](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/exceptions/)
+- Set `ActivityStatusCode.Ok` on success, `ActivityStatusCode.Error` on exception
+- Use `SetStatus` (the SDK translates it to OTel span status) — legacy `otel.status_code`/`otel.status_description` tags are no longer needed
+- Record exception events per [OTel conventions](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions_attributes/)
 
 ### Activity Events
 
 ```csharp
-// ✅ CORRECT: Use events for additional context (sparingly)
+// ✅ Use events for additional context (sparingly — stored in-memory until export)
 activity?.AddEvent(new ActivityEvent("ItemRetried", tags: new ActivityTagsCollection
 {
-    ["retry_attempt"] = retryCount,
-    ["next_retry_delay"] = delayMs
+    ["retry_attempt"] = retryCount
 }));
 
-// ❌ WRONG: Don't use events for verbose logging
-activity?.AddEvent(new ActivityEvent($"Step {i} completed")); // ❌ Use logging instead
+// ❌ Don't use events for verbose logging — use ILogger instead
 ```
-
-**Rules**:
-- Events stored in-memory until transmission (use sparingly)
-- Only for additional context; consider nested spans for multiple events
-- Use logging for verbose information
 
 ### Accessing Activities
 
 ```csharp
-// ❌ WRONG: Don't rely on Activity.Current when you need a specific span
-public async Task HandleAsync(Context context)
-{
-    var activity = Activity.Current; // ❌ Might be a user-created span, not yours
-    activity?.SetTag("custom", "value");
-}
+// ❌ WRONG: Activity.Current might be a user-created span, not yours
+var activity = Activity.Current;
 
-// ✅ CORRECT: Pass Activity explicitly or store it in a dedicated context object
-public async Task HandleAsync(Context context)
-{
-    if (context.TryGetActivity(out var activity))
-    {
-        activity?.SetTag("custom", "value");
-    }
-}
+// ✅ CORRECT: Pass Activity explicitly or via a dedicated context object
+if (context.TryGetActivity(out var activity)) { activity?.SetTag("custom", "value"); }
 ```
+
+### Span Links
+
+Links connect a span to other spans that are causally related but not in a direct
+parent-child relationship — batch processing, scatter/gather, trace boundary crossings.
+
+```csharp
+var links = new List<ActivityLink>
+{
+    new(activityContext1),
+    new(activityContext2),
+};
+
+var activity = ActivitySource.StartActivity(
+    ActivityKind.Internal, name: "batch-process", links: links);
+```
+
+See [traces-and-propagation-reference.md](traces-and-propagation-reference.md) for full
+link patterns including batch processing, scatter/gather, and trace boundary crossing.
+
+### Context Propagation
+
+Distributed tracing requires propagating trace context across process boundaries
+(HTTP calls, message queues, etc.) using W3C `traceparent` headers. In .NET this is
+handled by `DistributedContextPropagator`. The OTel SDK configures W3C TraceContext
+propagation by default.
+
+See [traces-and-propagation-reference.md](traces-and-propagation-reference.md) for
+propagation patterns, custom propagators, and manual inject/extract for non-standard transports.
 
 ## Metrics
 
 ### Meter and Metrics Class Setup
 
 ```csharp
-// ✅ CORRECT: Group metrics by feature/component
 public sealed class OrderProcessingMetrics : IDisposable
 {
-    private readonly Meter meter;
-    private readonly Histogram<double> processingDuration;
-    private readonly Counter<long> itemsProcessed;
-
-    public OrderProcessingMetrics()
-    {
-        meter = new Meter("MyApp.OrderProcessing", "1.0.0");
-
-        // Singular names, appropriate units, nested hierarchy
-        processingDuration = meter.CreateHistogram<double>(
-            "myapp.order.processing.duration",
-            unit: "s",
-            description: "Duration of order processing"
-        );
-
-        itemsProcessed = meter.CreateCounter<long>(
-            "myapp.order.processing.count",
-            unit: "{order}",
-            description: "Number of orders processed"
-        );
-    }
+    private readonly Meter meter = new("MyApp.OrderProcessing", "1.0.0");
+    private readonly Histogram<double> processingDuration =
+        meter.CreateHistogram<double>("myapp.order.processing.duration", unit: "s");
+    private readonly Counter<long> itemsProcessed =
+        meter.CreateCounter<long>("myapp.order.processing.count", unit: "{order}");
 
     public void Dispose() => meter.Dispose();
 }
 ```
 
 **Naming Conventions** (follow [OTel semantic conventions](https://opentelemetry.io/docs/specs/semconv/general/metrics/)):
-- Singular names (use `_count` suffix instead of pluralization)
-- Nested hierarchy: `myapp.order.processing.duration`
-- Define units (s, ms, {item}, {connection})
-- Avoid technical suffixes (`_counter`, `_histogram`)
+- Singular names, nested hierarchy: `myapp.order.processing.duration`
+- Define units (s, ms, {item}, {connection}); avoid technical suffixes (`_counter`, `_histogram`)
 - Start with pre-1.0.0 version until adoption proven
+
+### Instrument Type Overview
+
+.NET provides 7 metric instrument types. Choose the right one for your measurement:
+
+| Instrument | .NET API | Behavior | Typical Use |
+|------------|---------|----------|-------------|
+| **Counter** | `CreateCounter<T>` | Monotonically increasing | Request counts, error counts |
+| **UpDownCounter** | `CreateUpDownCounter<T>` | Increases or decreases | Queue size, active connections |
+| **Histogram** | `CreateHistogram<T>` | Distribution of values | Durations, response sizes |
+| **Gauge** | `CreateGauge<T>` (.NET 9+) | Synchronous instant value | Current measurement recording |
+| **ObservableCounter** | `CreateObservableCounter<T>` | Async callback, monotonic | Periodically polled totals |
+| **ObservableGauge** | `CreateObservableGauge<T>` | Async callback, non-monotonic | CPU/memory usage |
+| **ObservableUpDownCounter** | `CreateObservableUpDownCounter<T>` | Async callback, bi-directional | Active tasks by priority |
+
+See [metrics-and-instruments-reference.md](metrics-and-instruments-reference.md) for
+full creation and recording examples for every instrument type, including callback
+patterns for observable instruments.
 
 ### Metric Recording Method Naming
 
 ```csharp
-// ✅ CORRECT: Action/outcome-based naming, separate methods per outcome
-public sealed class OrderProcessingMetrics
-{
-    // Event happened: describe what occurred
-    public void OrderProcessingSucceeded(string orderType, TimeSpan duration)
-    {
-        processingDuration.Record(duration.TotalSeconds,
-            new KeyValuePair<string, object?>("myapp.order_type", orderType),
-            new KeyValuePair<string, object?>("outcome", "success")
-        );
-    }
+// ✅ Action/outcome-based naming, separate methods per outcome
+public void OrderProcessingSucceeded(string orderType, TimeSpan duration) { /* Record */ }
+public void OrderProcessingFailed(string orderType, Exception ex, TimeSpan duration) { /* Record */ }
+public void ConnectionOpened() => connectionsOpen.Add(1);
+public void ConnectionClosed() => connectionsOpen.Add(-1);
 
-    public void OrderProcessingFailed(string orderType, Exception exception, TimeSpan duration)
-    {
-        processingDuration.Record(duration.TotalSeconds,
-            new KeyValuePair<string, object?>("myapp.order_type", orderType),
-            new KeyValuePair<string, object?>("outcome", "failure"),
-            new KeyValuePair<string, object?>("exception.type", exception.GetType().Name)
-        );
-    }
-
-    public void ConnectionOpened() => connectionsOpen.Add(1);
-    public void ConnectionClosed() => connectionsOpen.Add(-1);
-}
-
-// ❌ WRONG: Various naming anti-patterns
-public void RecordOrderProcessingDuration(...) { } // ❌ Don't name after metric
-public void RecordError(bool succeeded, Exception? ex) { } // ❌ Confusing signature
+// ❌ WRONG: Name after metric, confusing signature
+public void RecordOrderProcessingDuration(...) { } // ❌ don't name after metric
+public void RecordError(bool succeeded, Exception? ex) { } // ❌ confusing signature
 ```
 
-**Rules** (inspired by ASP.NET Core patterns):
-- Name after action/outcome: `OrderProcessingSucceeded`, `RetryAttempted`, `ConnectionFailed`
-- NOT after metric name: avoid `RecordXxx`, `IncrementXxx`
-- Separate methods for different outcomes (avoid boolean flags + optional exceptions)
+**Rules**:
+- Name after action/outcome (`OrderProcessingSucceeded`), NOT after metric (`RecordXxx`)
+- Separate methods per outcome (avoid boolean flags + optional exceptions)
 - Event-based naming for state changes: `ConnectionOpened()`, `ItemQueued()`
 
 ### Metric Dimensions
 
 ```csharp
-// ✅ CORRECT: Low-cardinality, predefined dimensions
-public void OrderProcessingSucceeded(string orderType, TimeSpan duration)
-{
-    processingDuration.Record(duration.TotalSeconds,
-        new KeyValuePair<string, object?>("myapp.order_type", orderType),
-        new KeyValuePair<string, object?>("myapp.region", region),
-        new KeyValuePair<string, object?>("outcome", "success")
-    );
-}
+// ✅ Low-cardinality, predefined dimensions
+processingDuration.Record(duration.TotalSeconds,
+    new KeyValuePair<string, object?>("myapp.order_type", orderType),  // bounded set
+    new KeyValuePair<string, object?>("outcome", "success"));         // bounded set
 
-// ❌ WRONG: High-cardinality dimensions (unbounded values cause cardinality explosion)
-public void OrderFailed(string orderId, string exceptionMessage)
-{
-    failureCount.Add(1,
-        new KeyValuePair<string, object?>("order_id", orderId),               // ❌ Unbounded
-        new KeyValuePair<string, object?>("exception_message", exceptionMessage) // ❌ Unbounded
-    );
-}
+// ❌ High-cardinality: unbounded values cause cardinality explosion
+failureCount.Add(1, new KeyValuePair<string, object?>("order_id", orderId)); // ❌ unbounded
 ```
 
 **Rules**:
-- Dimensions MUST be predefined at instrument creation
-- Avoid dynamic/unbounded values (causes cardinality explosion: each unique value creates a new time series row)
+- Dimensions MUST be predefined and low-cardinality (item type, queue name, outcome)
+- Avoid unbounded values (each unique value = new time series row → cardinality explosion)
 - High-cardinality dimensions MUST be opt-in configuration
-- Use low-cardinality identifiers: item type, queue name, outcome
-- Consistent dimension names across components: `myapp.region` means same thing everywhere
-- Avoid sensitive data
-- Consider [metric enrichment alternatives](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics#metrics-enrichment)
-- Users can enable [metric exemplars](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics#metrics-correlation) for correlation (not through dimensions)
+- Consistent names across components: `myapp.region` means the same everywhere
+- Users can enable [exemplars](https://opentelemetry.io/docs/languages/dotnet/metrics/exemplars/) for trace correlation (not via dimensions)
 
 ## Performance Requirements
 
@@ -369,55 +397,29 @@ counter.Add(1, tags);
 ### Timing
 
 ```csharp
-// ✅ CORRECT: Timestamp math (no allocation)
+// ✅ Timestamp math (no allocation)
 var startTime = Stopwatch.GetTimestamp();
-try
-{
-    await ProcessAsync();
-}
-finally
-{
-    var duration = Stopwatch.GetElapsedTime(startTime);
-    metrics.OrderProcessingSucceeded(orderType, duration);
-}
+try { await ProcessAsync(); }
+finally { var duration = Stopwatch.GetElapsedTime(startTime); metrics.OrderProcessingSucceeded(orderType, duration); }
 
-// ❌ WRONG: Allocates Stopwatch object
-var stopwatch = Stopwatch.StartNew(); // ❌ Allocates
-
-// ❌ WRONG: IDisposable timing class (allocates per use)
-using (new MetricScope(metrics, "ProcessOrder")) // ❌ BAD
-{
-    ProcessOrder();
-}
+// ❌ Allocates: Stopwatch.StartNew() or IDisposable timing wrappers
 ```
 
 ### Avoid Hidden Allocations
 
 ```csharp
-// ❌ WRONG: String interpolation allocates
-activity?.SetTag("item", $"Processing {itemId}"); // ❌ Allocates
+// ❌ Allocates: string interpolation without IsAllDataRequested guard
+activity?.SetTag("item", $"Processing {itemId}"); // ❌
 
-// ✅ CORRECT: Check IsAllDataRequested first
+// ✅ Guard expensive work behind IsAllDataRequested
 if (activity?.IsAllDataRequested == true)
-{
     activity.SetTag("item", $"Processing {itemId}");
-}
-
-// ❌ WRONG: LINQ allocates enumerators
-activity?.SetTag("handlers", handlers.Select(h => h.Name).ToArray()); // ❌ Bad
-
-// ✅ CORRECT: Manual construction or check first
-if (activity?.IsAllDataRequested == true)
-{
-    activity.SetTag("handlers", string.Join(",", handlers.Select(h => h.Name)));
-}
 ```
 
 **Rules**:
-- No `Stopwatch.StartNew()` (use timestamp math)
-- No timing `IDisposable` wrappers as classes
+- No `Stopwatch.StartNew()` (use `Stopwatch.GetTimestamp()`/`GetElapsedTime`)
 - Prefer `TagList` (struct) over arrays/dictionaries
-- No hidden work: avoid LINQ, string interpolation, async state machines in hot paths
+- No LINQ, string interpolation, or async state machines in hot paths without guards
 
 ## Testing Requirements
 
@@ -464,14 +466,34 @@ private static readonly ActivitySource ActivitySource = new("MyApp.MyComponent",
 private readonly Meter meter = new("MyApp.MyComponent", "0.8.0");
 ```
 
+## Logs
+
+.NET logs integrate with OpenTelemetry through the built-in `ILogger` API. The OTel
+SDK provides `AddOpenTelemetry()` on the logging builder to collect, process, and export
+logs. Log records are automatically correlated with traces via `TraceId`/`SpanId`.
+
+See [sdk-resources-and-logs-reference.md](sdk-resources-and-logs-reference.md) for
+full logs integration patterns including correlation, redaction, structured logging,
+and severity filtering.
+
+## Reference Files
+
+- [traces-and-propagation-reference.md](traces-and-propagation-reference.md): SpanKind deep dive with examples, Span Links (batch, scatter/gather, trace boundary), Context Propagation (W3C traceparent, DistributedContextPropagator, custom propagators), Baggage, and the full modern exception recording pattern.
+- [metrics-and-instruments-reference.md](metrics-and-instruments-reference.md): All 7 metric instrument types with creation/recording code and when-to-use guidance, observable instrument callback patterns, dimensions deep dive, exemplars, aggregation defaults, and units.
+- [sdk-resources-and-logs-reference.md](sdk-resources-and-logs-reference.md): SDK initialization (ASP.NET Core + Console), Resource configuration (ResourceBuilder, AddService, AddDetector, custom detectors), Exporters (OTLP, Console, Jaeger, Zipkin, Prometheus), Instrumentation Libraries, Sampling (built-in, custom, env vars, head/tail-based), Logs integration (ILogger, correlation, redaction, structured logging), and environment variable configuration.
+
 ## References
 
-- [OpenTelemetry .NET Trace Documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/trace)
-- [OpenTelemetry .NET Metrics Documentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics)
-- [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/)
-- [Microsoft Distributed Tracing Instrumentation](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing-instrumentation-walkthroughs)
-- [ASP.NET Core Metrics Examples](https://github.com/search?q=repo%3Adotnet%2Faspnetcore+Metrics&type=code)
-- [OpenTelemetry Trace API Span Definition](https://opentelemetry.io/docs/specs/otel/trace/api/#span)
-- [OpenTelemetry Exception Conventions](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/exceptions/)
-- [OpenTelemetry Attribute Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/common#attribute)
-- [OpenTelemetry Cardinality Limits](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/docs/metrics/README.md#cardinality-limits)
+- [OTel Specification Overview](https://opentelemetry.io/docs/specs/otel/overview/)
+- [OTel Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/)
+- [OTel Common Spec (AnyValue)](https://opentelemetry.io/docs/specs/otel/common/)
+- [OTel Tracing SDK Spec](https://opentelemetry.io/docs/specs/otel/trace/sdk/)
+- [OTel Metrics SDK Spec](https://opentelemetry.io/docs/specs/otel/metrics/sdk/)
+- [OTel Logs Spec](https://opentelemetry.io/docs/specs/otel/logs/)
+- [OTel Resource Spec](https://opentelemetry.io/docs/specs/otel/resource/)
+- [OTel Context Spec](https://opentelemetry.io/docs/specs/otel/context/)
+- [.NET Observability with OpenTelemetry (MS Learn)](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-with-otel)
+- [OTel .NET Manual Instrumentation](https://opentelemetry.io/docs/languages/dotnet/instrumentation/)
+- [OTel .NET Metric Instruments](https://opentelemetry.io/docs/languages/dotnet/metrics/instruments/)
+- [OTel .NET Sampling](https://opentelemetry.io/docs/languages/dotnet/sampling/)
+- [OTel .NET Zero-Code Instrumentation](https://opentelemetry.io/docs/zero-code/net/)

--- a/skills/opentelementry-dotnet-instrumentation/SKILL.md
+++ b/skills/opentelementry-dotnet-instrumentation/SKILL.md
@@ -15,6 +15,7 @@ tags:
 # OpenTelemetry .NET Instrumentation Skill
 
 ## When to Use
+
 - Adding OpenTelemetry instrumentation to .NET code (traces, metrics, logs)
 - Creating or modifying ActivitySources, Meters, or ILogger usage
 - Setting up the OpenTelemetry SDK, resources, exporters, or sampling
@@ -459,9 +460,7 @@ private readonly Meter meter = new("MyApp.MyComponent", "0.8.0");
 
 .NET logs integrate with OpenTelemetry through the built-in `ILogger` API. The OTel SDK provides `AddOpenTelemetry()` on the logging builder to collect, process, and export logs. Log records are automatically correlated with traces via `TraceId`/`SpanId`.
 
-See [sdk-resources-and-logs-reference.md](sdk-resources-and-logs-reference.md) for
-full logs integration patterns including correlation, redaction, structured logging,
-and severity filtering.
+See [sdk-resources-and-logs-reference.md](sdk-resources-and-logs-reference.md) for full logs integration patterns including correlation, redaction, structured logging, and severity filtering.
 
 ## Reference Files
 

--- a/skills/opentelementry-dotnet-instrumentation/metrics-and-instruments-reference.md
+++ b/skills/opentelementry-dotnet-instrumentation/metrics-and-instruments-reference.md
@@ -1,12 +1,8 @@
 # Metrics and Instruments Reference
 
-Detailed reference for all metric instrument types in .NET,
-including observable instrument callback patterns, dimensions management,
-exemplars, aggregation, and units guidance.
+Detailed reference for all metric instrument types in .NET, including observable instrument callback patterns, dimensions management, exemplars, aggregation, and units guidance.
 
-This is a companion to [SKILL.md](SKILL.md). See it for core principles, the
-"System.Diagnostics first" architecture, metrics naming conventions, and
-metric recording method naming.
+This is a companion to [SKILL.md](SKILL.md). See it for core principles, the "System.Diagnostics-first" architecture, metrics naming conventions, and metric recording method naming.
 
 ## Table of Contents
 
@@ -29,9 +25,7 @@ metric recording method naming.
 
 ## Instrument Type Overview
 
-.NET provides 7 metric instrument types (the 6 defined by the OTel specification
-plus a synchronous `Gauge` added in .NET 9). All are available via
-`System.Diagnostics.Metrics.Meter`. They fall into two categories:
+.NET provides 7 metric instrument types (the 6 defined by the OTel specification plus a synchronous `Gauge` added in .NET 9). All are available via `System.Diagnostics.Metrics.Meter`. They fall into two categories:
 
 ### Synchronous Instruments (called when an event occurs)
 
@@ -72,8 +66,7 @@ Is the value a cumulative total that only goes up?
 
 ## Counter
 
-A Counter records a monotonically increasing value. You can only add non-negative
-values. Use for counting events: requests, errors, bytes transferred.
+A Counter records a monotonically increasing value. You can only add non-negative values. Use for counting events: requests, errors, and bytes transferred.
 
 ### Creating a Counter
 
@@ -113,8 +106,7 @@ bytesSentCounter.Add(1024,
 
 ## UpDownCounter
 
-An UpDownCounter records a value that can both increase and decrease. Use for
-tracking current values: queue sizes, active connections, resource pool usage.
+An UpDownCounter records a value that can both increase and decrease. Use for tracking current values: queue sizes, active connections, resource pool usage.
 
 ### Creating an UpDownCounter
 
@@ -149,9 +141,7 @@ activeConnections.Add(-1,
 
 ## Histogram
 
-A Histogram records the distribution of values — capturing count, sum, min, max,
-and configurable bucket boundaries for percentile estimation. Use for measuring
-durations, response sizes, and any value where you need percentiles (p50, p95, p99).
+A Histogram records the distribution of values — capturing count, sum, min, max, and configurable bucket boundaries for percentile estimation. Use for measuring durations, response sizes, and any value where you need percentiles (p50, p95, p99).
 
 ### Creating a Histogram
 
@@ -205,9 +195,7 @@ builder.Services.AddOpenTelemetry()
 
 ## Gauge (.NET 9+)
 
-A Gauge records the current value of a measurement at a specific point in time.
-This is a synchronous instrument — you call it when the event occurs. Use for
-non-cumulative instantaneous measurements.
+A Gauge records the current value of a measurement at a specific point in time. This is a synchronous instrument — you call it when the event occurs. Use for non-cumulative instantaneous measurements.
 
 ### Creating a Gauge
 
@@ -238,9 +226,7 @@ temperatureGauge.Record(23.5,
 
 ## ObservableCounter
 
-An ObservableCounter is an asynchronous instrument that reports a monotonically
-increasing value via a callback. The SDK calls the callback at collection intervals.
-Use for values that are maintained externally and only read periodically.
+An ObservableCounter is an asynchronous instrument that reports a monotonically increasing value via a callback. The SDK calls the callback at collection intervals. Use for values that are maintained externally and only read periodically.
 
 ### Creating an ObservableCounter
 
@@ -278,9 +264,7 @@ meter.CreateObservableCounter<long>(
 
 ## ObservableGauge
 
-An ObservableGauge is an asynchronous instrument that reports the current value
-of a measurement via a callback. Use for values read from the system at collection
-intervals: CPU usage, memory, temperature, queue depth.
+An ObservableGauge is an asynchronous instrument that reports the current measurement value via a callback. Use for values read from the system at collection intervals: CPU usage, memory, temperature, and queue depth.
 
 ### Creating an ObservableGauge
 
@@ -317,9 +301,7 @@ meter.CreateObservableGauge<double>(
 
 ## ObservableUpDownCounter
 
-An ObservableUpDownCounter is an asynchronous instrument that reports a value
-that can increase or decrease, via a callback. Use for tracking current counts
-that are maintained externally.
+An ObservableUpDownCounter is an asynchronous instrument that reports a value that can increase or decrease, via a callback. Use for tracking current counts that are maintained externally.
 
 ### Creating an ObservableUpDownCounter
 
@@ -345,9 +327,7 @@ meter.CreateObservableUpDownCounter<int>(
 
 ## Batching Observable Measurements
 
-For multiple observable instruments that share collection logic, define a single
-method that returns measurements. Each instrument registers independently with its
-own callback delegate that calls the shared logic:
+For multiple observable instruments that share collection logic, define a single method that returns measurements. Each instrument registers independently with its own callback delegate that calls the shared logic:
 
 ```csharp
 // Shared data-gathering method
@@ -360,8 +340,7 @@ var observableCounter = meter.CreateObservableCounter<long>(
     "myapp.items_processed", () => CollectProcessed(), unit: "{item}");
 ```
 
-For instruments of different numeric types, use separate callbacks. The key pattern
-is to share the underlying data-gathering logic, not to batch the SDK callback itself.
+For instruments of different numeric types, use separate callbacks. The key pattern is to share the underlying data-gathering logic, not to batch the SDK callback itself.
 
 ---
 
@@ -369,10 +348,7 @@ is to share the underlying data-gathering logic, not to batch the SDK callback i
 
 ### Cardinality Management
 
-Each unique combination of attribute key-value pairs creates a separate time series.
-High-cardinality dimensions (e.g., user IDs, request IDs, exception messages) cause
-**cardinality explosion** — each unique value creates a new time series row, leading
-to excessive memory and storage usage.
+Each unique combination of attribute key-value pairs creates a separate time series. High-cardinality dimensions (e.g., user IDs, request IDs, exception messages) cause **cardinality explosion** — each unique value creates a new time series row, leading to excessive memory and storage usage.
 
 ```csharp
 // ✅ CORRECT: Low-cardinality dimensions — finite, small set of values
@@ -390,12 +366,9 @@ counter.Add(1,
 
 ### Cardinality Limits in the OTel SDK
 
-The OTel .NET SDK has a configurable cardinality limit (default: 2000 attribute
-combinations per instrument). When exceeded, new combinations are dropped. This is
-a safety valve, not a design target — you should design for low cardinality.
+The OTel .NET SDK has a configurable cardinality limit (default: 2000 attribute combinations per instrument). When exceeded, new combinations are dropped. This is a safety valve, not a design target — you should design for low cardinality.
 
-Configure via the `OTEL_DOTNET_EXPERIMENTAL_METRICS_CARDINALITY_LIMIT` environment
-variable or in code.
+Configure via the `OTEL_DOTNET_EXPERIMENTAL_METRICS_CARDINALITY_LIMIT` environment variable or in code.
 
 ### High-Cardinality Opt-In Pattern
 
@@ -440,11 +413,7 @@ public sealed class OrderProcessingMetrics : IDisposable
 
 ## Exemplars
 
-[Exemplars](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#exemplar) are
-metric measurements that carry an associated trace context (TraceId/SpanId).
-They enable correlating metric data points with specific traces, making it
-possible to jump from a metric spike in a dashboard to the exact trace that
-contributed to that measurement.
+[Exemplars](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#exemplar) are metric measurements that carry an associated trace context (TraceId/SpanId). They enable correlating metric data points with specific traces, allowing jumping from a metric spike on a dashboard to the exact trace that contributed to that measurement.
 
 ### Enabling Exemplars in .NET
 
@@ -485,8 +454,7 @@ The SDK provides default reservoirs:
 | `AlignedHistogramBucketExemplarReservoir` | One exemplar per histogram bucket (default for histograms) |
 | `SimpleFixedSizeExemplarReservoir` | Fixed-size pool, randomly samples |
 
-You typically don't configure these directly — the SDK selects appropriate
-defaults based on instrument type.
+You typically don't configure these directly — the SDK selects appropriate defaults based on instrument type.
 
 See [OTel .NET: Using Exemplars](https://opentelemetry.io/docs/languages/dotnet/metrics/exemplars/).
 
@@ -494,8 +462,7 @@ See [OTel .NET: Using Exemplars](https://opentelemetry.io/docs/languages/dotnet/
 
 ## Aggregation Defaults
 
-The SDK applies default aggregations based on instrument type. You can override
-these via **Views**:
+The SDK applies default aggregations based on instrument type. You can override these via **Views**:
 
 | Instrument | Default Aggregation |
 |------------|---------------------|
@@ -547,9 +514,7 @@ OTel uses [UCUM (Unified Code for Units of Measure)](https://ucum.org/) notation
 
 ### Annotated Units
 
-Use curly braces for "annotated" units — units that represent a count of something
-specific: `{request}`, `{order}`, `{connection}`, `{message}`. This distinguishes
-them from plain integers and enables better semantic interpretation by backends.
+Use curly braces for "annotated" units — units that represent a count of something specific: `{request}`, `{order}`, `{connection}`, `{message}`. This distinguishes them from plain integers and enables backends to interpret them more semantically.
 
 ### Rules
 

--- a/skills/opentelementry-dotnet-instrumentation/metrics-and-instruments-reference.md
+++ b/skills/opentelementry-dotnet-instrumentation/metrics-and-instruments-reference.md
@@ -1,0 +1,574 @@
+# Metrics and Instruments Reference
+
+Detailed reference for all metric instrument types in .NET,
+including observable instrument callback patterns, dimensions management,
+exemplars, aggregation, and units guidance.
+
+This is a companion to [SKILL.md](SKILL.md). See it for core principles, the
+"System.Diagnostics first" architecture, metrics naming conventions, and
+metric recording method naming.
+
+## Table of Contents
+
+- [Instrument Type Overview](#instrument-type-overview)
+- [Counter](#counter)
+- [UpDownCounter](#updowncounter)
+- [Histogram](#histogram)
+- [Gauge (.NET 9+)](#gauge-net-9)
+- [ObservableCounter](#observablecounter)
+- [ObservableGauge](#observablegauge)
+- [ObservableUpDownCounter](#observableupdowncounter)
+- [Batching Observable Measurements](#batching-observable-measurements)
+- [Dimensions Deep Dive](#dimensions-deep-dive)
+- [Exemplars](#exemplars)
+- [Aggregation Defaults](#aggregation-defaults)
+- [Units Guidance](#units-guidance)
+- [References](#references)
+
+---
+
+## Instrument Type Overview
+
+.NET provides 7 metric instrument types (the 6 defined by the OTel specification
+plus a synchronous `Gauge` added in .NET 9). All are available via
+`System.Diagnostics.Metrics.Meter`. They fall into two categories:
+
+### Synchronous Instruments (called when an event occurs)
+
+| Instrument | .NET API | Monotonic | Typical Use |
+|-----------|---------|-----------|-------------|
+| **Counter** | `CreateCounter<T>` | Yes (increasing only) | Request counts, error counts, bytes sent |
+| **UpDownCounter** | `CreateUpDownCounter<T>` | No (up or down) | Queue size, active connections, memory in use |
+| **Histogram** | `CreateHistogram<T>` | N/A (distribution) | Request durations, response sizes, latency percentiles |
+| **Gauge** | `CreateGauge<T>` (.NET 9+) | No (instant value) | Current temperature, voltage, non-cumulative measurement |
+
+### Asynchronous/Observable Instruments (called on collection interval)
+
+| Instrument | .NET API | Monotonic | Typical Use |
+|-----------|---------|-----------|-------------|
+| **ObservableCounter** | `CreateObservableCounter<T>` | Yes | Total CPU time, total bytes read since startup |
+| **ObservableGauge** | `CreateObservableGauge<T>` | No | Current CPU usage %, current memory, queue depth |
+| **ObservableUpDownCounter** | `CreateObservableUpDownCounter<T>` | No | Active tasks by priority, current connections by type |
+
+### Choosing an Instrument
+
+```
+Is the value a cumulative total that only goes up?
+  → YES: Can you increment it on every event?
+           → YES: Counter (synchronous)
+           → NO (polled periodically):  ObservableCounter (async)
+  → NO:  Is it a distribution/percentile you need?
+           → YES: Histogram
+  → NO:  Can the value go both up AND down?
+           → YES: Can you update it on every event?
+                    → YES: UpDownCounter (synchronous)
+                    → NO (polled periodically): ObservableUpDownCounter (async)
+           → NO (instantaneous snapshot): Can you record it on every event?
+                    → YES: Gauge (synchronous, .NET 9+)
+                    → NO (polled periodically): ObservableGauge (async)
+```
+
+---
+
+## Counter
+
+A Counter records a monotonically increasing value. You can only add non-negative
+values. Use for counting events: requests, errors, bytes transferred.
+
+### Creating a Counter
+
+```csharp
+var meter = new Meter("MyCompany.MyProduct", "1.0.0");
+
+var requestCounter = meter.CreateCounter<long>(
+    "myapp.request_count",
+    unit: "{request}",
+    description: "Number of requests received");
+```
+
+### Recording Measurements
+
+```csharp
+// Increment by 1
+requestCounter.Add(1);
+
+// Increment with attributes (tags/dimensions)
+requestCounter.Add(1,
+    new KeyValuePair<string, object?>("http.request.method", "GET"),
+    new KeyValuePair<string, object?>("http.route", "/api/users"));
+
+// Increment by larger amount
+bytesSentCounter.Add(1024,
+    new KeyValuePair<string, object?>("myapp.endpoint", "/download"));
+```
+
+### Rules
+
+- Values MUST be non-negative (adding a negative value throws at runtime)
+- Use `long` or `int` for counts, `double` for fractional measurements
+- The SDK aggregates by summing all recorded values per unique attribute set
+- Aggregation: **Sum** (monotonic)
+
+---
+
+## UpDownCounter
+
+An UpDownCounter records a value that can both increase and decrease. Use for
+tracking current values: queue sizes, active connections, resource pool usage.
+
+### Creating an UpDownCounter
+
+```csharp
+var activeConnections = meter.CreateUpDownCounter<int>(
+    "myapp.active_connections",
+    unit: "{connection}",
+    description: "Number of active connections");
+```
+
+### Recording Measurements
+
+```csharp
+// Connection opened → +1
+activeConnections.Add(1,
+    new KeyValuePair<string, object?>("myapp.protocol", "https"));
+
+// Connection closed → -1
+activeConnections.Add(-1,
+    new KeyValuePair<string, object?>("myapp.protocol", "https"));
+```
+
+### Rules
+
+- Values can be positive or negative
+- The SDK tracks the net sum per unique attribute set
+- Aggregation: **Sum** (non-monotonic)
+- Use when you need to track a value that changes over time but don't need
+  a distribution/percentile view (use Histogram for that)
+
+---
+
+## Histogram
+
+A Histogram records the distribution of values — capturing count, sum, min, max,
+and configurable bucket boundaries for percentile estimation. Use for measuring
+durations, response sizes, and any value where you need percentiles (p50, p95, p99).
+
+### Creating a Histogram
+
+```csharp
+var requestDuration = meter.CreateHistogram<double>(
+    "myapp.request.duration",
+    unit: "ms",
+    description: "Request duration in milliseconds");
+```
+
+### Recording Measurements
+
+```csharp
+var startTime = Stopwatch.GetTimestamp();
+try
+{
+    await ProcessRequestAsync();
+}
+finally
+{
+    var duration = Stopwatch.GetElapsedTime(startTime);
+    requestDuration.Record(duration.TotalMilliseconds,
+        new KeyValuePair<string, object?>("http.route", "/api/orders"),
+        new KeyValuePair<string, object?>("http.request.method", "POST"));
+}
+```
+
+### Custom Bucket Boundaries
+
+The OTel SDK allows configuring explicit bucket boundaries via views:
+
+```csharp
+// Application setup: configure histogram buckets
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics => metrics
+        .AddMeter("MyCompany.MyProduct")
+        .AddView("myapp.request.duration", new ExplicitBucketHistogramConfiguration
+        {
+            Boundaries = new double[] { 0, 5, 10, 25, 50, 75, 100, 250, 500, 1000 }
+        }));
+```
+
+### Rules
+
+- Records individual measurements (not sums)
+- The SDK aggregates into: count, sum, min, max, bucket counts
+- Default boundaries vary by SDK version; configure explicitly for your use case
+- Aggregation: **Explicit Bucket Histogram** by default
+
+---
+
+## Gauge (.NET 9+)
+
+A Gauge records the current value of a measurement at a specific point in time.
+This is a synchronous instrument — you call it when the event occurs. Use for
+non-cumulative instantaneous measurements.
+
+### Creating a Gauge
+
+```csharp
+// .NET 9+ only
+var temperatureGauge = meter.CreateGauge<double>(
+    "myapp.sensor.temperature",
+    unit: "Cel",
+    description: "Current temperature reading");
+```
+
+### Recording Measurements
+
+```csharp
+temperatureGauge.Record(23.5,
+    new KeyValuePair<string, object?>("myapp.sensor_id", "sensor-01"));
+```
+
+### Rules
+
+- Available in .NET 9 and later
+- Records the latest value (not a sum)
+- Use when you have the value at call time and don't need polling
+- For polled values (e.g., CPU usage read from OS), use `ObservableGauge` instead
+- Aggregation: **Last Value** (Gauge)
+
+---
+
+## ObservableCounter
+
+An ObservableCounter is an asynchronous instrument that reports a monotonically
+increasing value via a callback. The SDK calls the callback at collection intervals.
+Use for values that are maintained externally and only read periodically.
+
+### Creating an ObservableCounter
+
+```csharp
+var totalBytesRead = meter.CreateObservableCounter<long>(
+    "myapp.io.bytes_read",
+    () => GetTotalBytesRead(),  // callback returning current value
+    unit: "By",
+    description: "Total bytes read since startup");
+```
+
+### With Tags
+
+```csharp
+meter.CreateObservableCounter<long>(
+    "myapp.io.bytes_read",
+    () => new[]
+    {
+        new Measurement<long>(GetBytesRead("disk"), new KeyValuePair<string, object?>("myapp.device", "disk")),
+        new Measurement<long>(GetBytesRead("network"), new KeyValuePair<string, object?>("myapp.device", "network"))
+    },
+    unit: "By",
+    description: "Total bytes read since startup");
+```
+
+### Rules
+
+- Callback is invoked by the SDK at collection intervals (not on every event)
+- Callback returns `Measurement<T>` or `IEnumerable<Measurement<T>>`
+- Values must be non-negative (monotonic)
+- No `Add()` or `Record()` method — values come from the callback
+- Aggregation: **Sum** (monotonic)
+
+---
+
+## ObservableGauge
+
+An ObservableGauge is an asynchronous instrument that reports the current value
+of a measurement via a callback. Use for values read from the system at collection
+intervals: CPU usage, memory, temperature, queue depth.
+
+### Creating an ObservableGauge
+
+```csharp
+var cpuUsageGauge = meter.CreateObservableGauge<double>(
+    "myapp.cpu.usage",
+    () => new Measurement<double>(GetCurrentCpuUsage()),
+    unit: "%",
+    description: "Current CPU usage percentage");
+```
+
+### With Tags
+
+```csharp
+meter.CreateObservableGauge<double>(
+    "myapp.cpu.usage",
+    () => new[]
+    {
+        new Measurement<double>(GetCpuUsage("core0"), new KeyValuePair<string, object?>("myapp.core", "0")),
+        new Measurement<double>(GetCpuUsage("core1"), new KeyValuePair<string, object?>("myapp.core", "1"))
+    },
+    unit: "%",
+    description: "Current CPU usage percentage per core");
+```
+
+### Rules
+
+- Callback invoked at collection intervals
+- Values can go up or down (non-monotonic)
+- Reports the last observed value
+- Aggregation: **Last Value** (Gauge)
+
+---
+
+## ObservableUpDownCounter
+
+An ObservableUpDownCounter is an asynchronous instrument that reports a value
+that can increase or decrease, via a callback. Use for tracking current counts
+that are maintained externally.
+
+### Creating an ObservableUpDownCounter
+
+```csharp
+meter.CreateObservableUpDownCounter<int>(
+    "myapp.active_tasks",
+    () => new[]
+    {
+        new Measurement<int>(GetHighPriorityTaskCount(), new KeyValuePair<string, object?>("myapp.priority", "high")),
+        new Measurement<int>(GetLowPriorityTaskCount(), new KeyValuePair<string, object?>("myapp.priority", "low"))
+    },
+    unit: "{task}",
+    description: "Current number of active tasks by priority");
+```
+
+### Rules
+
+- Callback invoked at collection intervals
+- Values can go up or down
+- Aggregation: **Sum** (non-monotonic)
+
+---
+
+## Batching Observable Measurements
+
+For multiple observable instruments that share collection logic, define a single
+method that returns measurements. Each instrument registers independently with its
+own callback delegate that calls the shared logic:
+
+```csharp
+// Shared data-gathering method
+static IEnumerable<Measurement<long>> CollectProcessed() =>
+    new[] { new Measurement<long>(GetProcessedCount(),
+        new KeyValuePair<string, object?>("myapp.queue", "default")) };
+
+// Each instrument registers with its own callback
+var observableCounter = meter.CreateObservableCounter<long>(
+    "myapp.items_processed", () => CollectProcessed(), unit: "{item}");
+```
+
+For instruments of different numeric types, use separate callbacks. The key pattern
+is to share the underlying data-gathering logic, not to batch the SDK callback itself.
+
+---
+
+## Dimensions Deep Dive
+
+### Cardinality Management
+
+Each unique combination of attribute key-value pairs creates a separate time series.
+High-cardinality dimensions (e.g., user IDs, request IDs, exception messages) cause
+**cardinality explosion** — each unique value creates a new time series row, leading
+to excessive memory and storage usage.
+
+```csharp
+// ✅ CORRECT: Low-cardinality dimensions — finite, small set of values
+counter.Add(1,
+    new KeyValuePair<string, object?>("myapp.operation", "checkout"),
+    new KeyValuePair<string, object?>("myapp.region", "us-east-1"),
+    new KeyValuePair<string, object?>("outcome", "success"));
+
+// ❌ WRONG: High-cardinality — unbounded values
+counter.Add(1,
+    new KeyValuePair<string, object?>("order_id", orderId),          // thousands of unique values
+    new KeyValuePair<string, object?>("user_email", userEmail),       // thousands of unique values
+    new KeyValuePair<string, object?>("exception_message", exMsg);   // unpredictable values
+```
+
+### Cardinality Limits in the OTel SDK
+
+The OTel .NET SDK has a configurable cardinality limit (default: 2000 attribute
+combinations per instrument). When exceeded, new combinations are dropped. This is
+a safety valve, not a design target — you should design for low cardinality.
+
+Configure via the `OTEL_DOTNET_EXPERIMENTAL_METRICS_CARDINALITY_LIMIT` environment
+variable or in code.
+
+### High-Cardinality Opt-In Pattern
+
+```csharp
+public sealed class OrderProcessingMetrics : IDisposable
+{
+    private readonly Meter _meter;
+    private readonly Histogram<double> _processingDuration;
+    private readonly bool _enableHighCardinalityDimensions;
+
+    public OrderProcessingMetrics(IConfiguration config)
+    {
+        _meter = new Meter("MyApp.OrderProcessing", "1.0.0");
+        _enableHighCardinalityDimensions = config.GetValue("Metrics:EnableHighCardinality", false);
+
+        _processingDuration = _meter.CreateHistogram<double>(
+            "myapp.order.processing.duration", unit: "s");
+    }
+
+    public void OrderProcessingSucceeded(string orderType, TimeSpan duration, string? orderId = null)
+    {
+        var tags = new TagList
+        {
+            { "myapp.order_type", orderType },
+            { "outcome", "success" }
+        };
+
+        // High-cardinality dimension only when explicitly opted in
+        if (_enableHighCardinalityDimensions && orderId != null)
+        {
+            tags.Add("myapp.order_id", orderId);
+        }
+
+        _processingDuration.Record(duration.TotalSeconds, tags);
+    }
+
+    public void Dispose() => _meter.Dispose();
+}
+```
+
+---
+
+## Exemplars
+
+[Exemplars](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#exemplar) are
+metric measurements that carry an associated trace context (TraceId/SpanId).
+They enable correlating metric data points with specific traces, making it
+possible to jump from a metric spike in a dashboard to the exact trace that
+contributed to that measurement.
+
+### Enabling Exemplars in .NET
+
+Exemplars are enabled via configuration in the OTel .NET SDK:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics => metrics
+        .AddMeter("MyApp.OrderProcessing")
+        .AddOtlpExporter(options =>
+        {
+            // Exemplars are supported in the OTLP exporter
+        }));
+```
+
+Or via environment variable:
+
+```
+OTEL_DOTNET_EXPERIMENTAL_METRICS_EXEMPLAR_FILTER=always_on
+# or: trace_based (only for sampled traces)
+```
+
+### How Exemplars Work
+
+1. When a metric is recorded within an active trace, the SDK may store the
+   current `TraceId`/`SpanId` alongside the measurement (exemplar)
+2. The exemplar reservoir decides which measurements to keep (sampling)
+3. Exporters that support exemplars (OTLP) include them in the exported data
+4. Visualization tools (Grafana, Jaeger) can link from the metric data point
+   to the trace
+
+### Exemplar Reservoirs
+
+The SDK provides default reservoirs:
+
+| Reservoir | Behavior |
+|-----------|----------|
+| `AlignedHistogramBucketExemplarReservoir` | One exemplar per histogram bucket (default for histograms) |
+| `SimpleFixedSizeExemplarReservoir` | Fixed-size pool, randomly samples |
+
+You typically don't configure these directly — the SDK selects appropriate
+defaults based on instrument type.
+
+See [OTel .NET: Using Exemplars](https://opentelemetry.io/docs/languages/dotnet/metrics/exemplars/).
+
+---
+
+## Aggregation Defaults
+
+The SDK applies default aggregations based on instrument type. You can override
+these via **Views**:
+
+| Instrument | Default Aggregation |
+|------------|---------------------|
+| Counter | Sum (monotonic) |
+| UpDownCounter | Sum (non-monotonic) |
+| Histogram | Explicit Bucket Histogram |
+| Gauge | Last Value |
+| ObservableCounter | Sum (monotonic) |
+| ObservableGauge | Last Value |
+| ObservableUpDownCounter | Sum (non-monotonic) |
+
+### Overriding Aggregation with Views
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics => metrics
+        .AddMeter("MyCompany.MyProduct")
+        // Change a histogram to use custom bucket boundaries
+        .AddView("myapp.request.duration", new ExplicitBucketHistogramConfiguration
+        {
+            Boundaries = new double[] { 0, 5, 10, 25, 50, 75, 100, 250, 500, 1000 }
+        })
+        // Drop an instrument entirely
+        .AddView("myapp.internal.debug_metric", MetricStreamConfiguration.Drop)
+        // Rename an instrument for export
+        .AddView(instrumentName: "myapp.old_name", name: "myapp.new_name"));
+```
+
+---
+
+## Units Guidance
+
+Follow the [OTel semantic conventions for units](https://opentelemetry.io/docs/specs/semconv/general/metrics/):
+
+### UCUM Notation
+
+OTel uses [UCUM (Unified Code for Units of Measure)](https://ucum.org/) notation:
+
+| Unit | Notation | Example |
+|------|----------|---------|
+| seconds | `s` | `"s"` |
+| milliseconds | `ms` | `"ms"` |
+| bytes | `By` | `"By"` |
+| bits | `bit` | `"bit"` |
+| percent | `%` | `"%"` |
+| count (annotated) | `{request}` | `"{request}"` |
+| count (annotated) | `{order}` | `"{order}"` |
+| count (annotated) | `{connection}` | `"{connection}"` |
+
+### Annotated Units
+
+Use curly braces for "annotated" units — units that represent a count of something
+specific: `{request}`, `{order}`, `{connection}`, `{message}`. This distinguishes
+them from plain integers and enables better semantic interpretation by backends.
+
+### Rules
+
+- Always specify a unit (even if it's `1` for dimensionless)
+- Use UCUM notation, not arbitrary strings (`"ms"` not `"milliseconds"`)
+- For counts, use annotated units: `"{order}"` not `"count"` or `"orders"`
+- The SDK does NOT validate units (per spec) — be consistent within your codebase
+
+---
+
+## References
+
+- [OTel Metrics API Specification](https://opentelemetry.io/docs/specs/otel/metrics/api/)
+- [OTel Metrics SDK Specification](https://opentelemetry.io/docs/specs/otel/metrics/sdk/)
+- [OTel .NET: Metric Instruments](https://opentelemetry.io/docs/languages/dotnet/metrics/instruments/)
+- [OTel .NET: Using Exemplars](https://opentelemetry.io/docs/languages/dotnet/metrics/exemplars/)
+- [OTel .NET: Metrics Best Practices](https://opentelemetry.io/docs/languages/dotnet/metrics/best-practices/)
+- [OTel Semantic Conventions: General Metrics](https://opentelemetry.io/docs/specs/semconv/general/metrics/)
+- [OTel Exemplar Specification](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#exemplar)
+- [OTel Aggregation Specification](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#aggregation)
+- [OTel Cardinality Limits (.NET)](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/docs/metrics/README.md#cardinality-limits)
+- [UCUM Units of Measure](https://ucum.org/)

--- a/skills/opentelementry-dotnet-instrumentation/sdk-resources-and-logs-reference.md
+++ b/skills/opentelementry-dotnet-instrumentation/sdk-resources-and-logs-reference.md
@@ -1,0 +1,798 @@
+# SDK Setup, Resources, Sampling, and Logs Reference
+
+Detailed reference for OpenTelemetry SDK initialization, resource configuration,
+exporters, instrumentation libraries, sampling, logs integration, and environment
+variable configuration in .NET.
+
+This is a companion to [SKILL.md](SKILL.md). See it for core principles and the
+"System.Diagnostics first" architecture.
+
+**Key principle**: SDK setup, resources, exporters, and sampling are **application
+concerns** — they are configured at the application composition root, NOT in libraries.
+Library authors use only `System.Diagnostics.*` and `ILogger`; the consuming application
+wires up the OTel SDK.
+
+## Table of Contents
+
+- [SDK Initialization](#sdk-initialization)
+- [Resources](#resources)
+- [Exporters](#exporters)
+- [Instrumentation Libraries](#instrumentation-libraries)
+- [Sampling](#sampling)
+- [Logs](#logs)
+- [Environment Variable Configuration](#environment-variable-configuration)
+- [Zero-Code Instrumentation](#zero-code-instrumentation)
+- [References](#references)
+
+---
+
+## SDK Initialization
+
+### ASP.NET Core / Generic Host
+
+Use the `OpenTelemetry.Extensions.Hosting` package and the `AddOpenTelemetry()` builder:
+
+```csharp
+// Program.cs — Application code (NOT library code)
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource
+        .AddService(serviceName: "myapp", serviceVersion: "1.0.0"))
+    .WithTracing(tracing => tracing
+        .AddSource("MyApp.MyComponent")           // your ActivitySource
+        .AddAspNetCoreInstrumentation()           // auto-trace HTTP requests
+        .AddHttpClientInstrumentation()           // auto-trace HTTP client calls
+        .AddOtlpExporter())                       // export via OTLP
+    .WithMetrics(metrics => metrics
+        .AddMeter("MyApp.OrderProcessing")        // your Meter
+        .AddAspNetCoreInstrumentation()           // auto-collect ASP.NET Core metrics
+        .AddRuntimeInstrumentation()              // .NET runtime metrics
+        .AddOtlpExporter());
+
+// Logs: configure on the logging builder
+builder.Logging.AddOpenTelemetry(options => options
+    .SetResourceBuilder(
+        ResourceBuilder.CreateDefault().AddService("myapp", serviceVersion: "1.0.0"))
+    .AddOtlpExporter());
+
+var app = builder.Build();
+app.Run();
+```
+
+**NuGet packages needed** (application only):
+
+```bash
+dotnet add package OpenTelemetry.Extensions.Hosting
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+dotnet add package OpenTelemetry.Instrumentation.Http
+dotnet add package OpenTelemetry.Instrumentation.Runtime
+```
+
+### Console Application (No DI)
+
+For console apps without the generic host, use the SDK directly:
+
+```csharp
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Metrics;
+
+var serviceName = "myapp";
+var serviceVersion = "1.0.0";
+
+// Traces
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddSource(serviceName)
+    .ConfigureResource(resource => resource
+        .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
+    .AddConsoleExporter()
+    .Build();
+
+// Metrics
+using var meterProvider = Sdk.CreateMeterProviderBuilder()
+    .AddMeter(serviceName)
+    .ConfigureResource(resource => resource
+        .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
+    .AddConsoleExporter()
+    .Build();
+
+// Run your application...
+```
+
+### Logs (Console Application)
+
+```csharp
+using var loggerFactory = LoggerFactory.Create(builder => builder
+    .AddOpenTelemetry(options =>
+    {
+        options.SetResourceBuilder(
+            ResourceBuilder.CreateDefault().AddService("myapp"));
+        options.AddOtlpExporter();
+    }));
+
+var logger = loggerFactory.CreateLogger<Program>();
+logger.LogInformation("Application started");
+```
+
+### Important: Dispose Providers
+
+Always dispose `TracerProvider` and `MeterProvider` (use `using` or call `.Dispose()`)
+to flush buffered data to exporters on shutdown:
+
+```csharp
+// ✅ CORRECT: using ensures flush on exit
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    // ...
+    .Build();
+
+// ❌ WRONG: data may be lost on exit — no flush
+var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    // ...
+    .Build();
+```
+
+---
+
+## Resources
+
+[Resources](https://opentelemetry.io/docs/specs/otel/resource/) capture information
+about the entity producing telemetry — "what" produced the signal. Every telemetry
+signal (trace, metric, log) should carry a Resource so you can identify its origin.
+
+### ResourceBuilder API
+
+```csharp
+// ✅ CORRECT: Use the fluent builder
+var resourceBuilder = ResourceBuilder
+    .CreateDefault()                    // auto-detects: service.name, service.instance.id, process info
+    .AddService(                         // explicitly set service identity
+        serviceName: "myapp",
+        serviceVersion: "1.0.0")
+    .AddAttributes(new Dictionary<string, object>
+    {
+        ["deployment.environment.name"] = "production",
+        ["team.name"] = "backend",
+        ["host.name"] = Environment.MachineName
+    });
+```
+
+### What CreateDefault Detects
+
+`ResourceBuilder.CreateDefault()` automatically populates:
+
+| Attribute | Source |
+|-----------|--------|
+| `service.name` | From `OTEL_SERVICE_NAME` env var, or `unknown_service` if not set |
+| `service.instance.id` | Auto-generated unique ID per process |
+| `process.pid` | Current process ID |
+| `process.runtime.name` | e.g., `.NET` |
+| `process.runtime.version` | e.g., `8.0.0` |
+| `host.name` | Machine name |
+
+### Adding Custom Resources via ConfigureResource
+
+When using `AddOpenTelemetry()`, configure resources for all signals at once:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource
+        .AddService("myapp", serviceVersion: "1.0.0")
+        .AddAttributes(new Dictionary<string, object>
+        {
+            ["deployment.environment.name"] = builder.Configuration["Environment"],
+            ["team.name"] = "payments-team"
+        }));
+```
+
+### Custom Resource Detectors
+
+Implement `IResourceDetector` for custom resource detection (e.g., reading from
+cloud metadata endpoints, Kubernetes downward API):
+
+```csharp
+public class KubernetesResourceDetector : IResourceDetector
+{
+    public Resource Detect()
+    {
+        var attributes = new Dictionary<string, object>();
+
+        // Read from Kubernetes downward API or environment
+        var podName = Environment.GetEnvironmentVariable("POD_NAME");
+        if (!string.IsNullOrEmpty(podName))
+        {
+            attributes["k8s.pod.name"] = podName;
+        }
+
+        var namespaceName = Environment.GetEnvironmentVariable("POD_NAMESPACE");
+        if (!string.IsNullOrEmpty(namespaceName))
+        {
+            attributes["k8s.namespace.name"] = namespaceName;
+        }
+
+        return new Resource(attributes);
+    }
+}
+
+// Register the detector
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource
+        .AddService("myapp")
+        .AddDetector(new KubernetesResourceDetector()));
+```
+
+### Resource via Environment Variables
+
+Set resources without code changes:
+
+```bash
+# Single attribute
+export OTEL_SERVICE_NAME=myapp
+
+# Multiple attributes (comma-separated)
+export OTEL_RESOURCE_ATTRIBUTES="service.name=myapp,service.version=1.0.0,deployment.environment.name=production"
+```
+
+### Key Resource Semantic Conventions
+
+| Attribute | Description | Source |
+|-----------|-------------|--------|
+| `service.name` | **Required** — logical service name | `AddService()` or env var |
+| `service.version` | Service version | `AddService()` |
+| `service.instance.id` | Unique instance ID (auto) | `CreateDefault()` |
+| `deployment.environment.name` | Environment (staging, production) | `AddAttributes()` |
+| `host.name` | Host machine name | `CreateDefault()` or manual |
+| `process.pid` | Process ID | `CreateDefault()` |
+| `process.runtime.name` | Runtime name | `CreateDefault()` |
+| `process.runtime.version` | Runtime version | `CreateDefault()` |
+| `k8s.pod.name` | Kubernetes pod name | Custom detector |
+| `k8s.namespace.name` | Kubernetes namespace | Custom detector |
+| `cloud.provider` | Cloud provider (aws, azure, gcp) | Custom detector |
+
+See the [full resource semantic conventions](https://opentelemetry.io/docs/specs/semconv/resource/).
+
+---
+
+## Exporters
+
+Exporters send telemetry data to observability backends. Configure them at the
+application composition root.
+
+### OTLP (Recommended for Production)
+
+The [OTLP exporter](https://opentelemetry.io/docs/specs/otel/protocol/) sends data
+to an OTLP-compatible collector or backend (Jaeger, Tempo, Honeycomb, Datadog, etc.):
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddSource("MyApp.MyComponent")
+        .AddOtlpExporter(options =>
+        {
+            options.Endpoint = new Uri("http://otel-collector:4317");
+            options.Protocol = OtlpExportProtocol.Grpc;
+        }))
+    .WithMetrics(metrics => metrics
+        .AddMeter("MyApp.OrderProcessing")
+        .AddOtlpExporter(options =>
+        {
+            options.Endpoint = new Uri("http://otel-collector:4317");
+            options.Protocol = OtlpExportProtocol.Grpc;
+        }));
+```
+
+```bash
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+```
+
+Default endpoint: `http://localhost:4317` (gRPC) or `http://localhost:4318` (HTTP/protobuf).
+
+Configure via environment variables:
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+```
+
+### Console (Development/Debug)
+
+```csharp
+.WithTracing(tracing => tracing
+    .AddSource("MyApp.MyComponent")
+    .AddConsoleExporter())
+.WithMetrics(metrics => metrics
+    .AddMeter("MyApp.OrderProcessing")
+    .AddConsoleExporter())
+```
+
+```bash
+dotnet add package OpenTelemetry.Exporter.Console
+```
+
+### Prometheus (Metrics Scrape Endpoint)
+
+Exposes a `/metrics` endpoint for Prometheus scraping:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics => metrics
+        .AddMeter("MyApp.OrderProcessing")
+        .AddPrometheusExporter());
+
+// Add the scrape endpoint middleware
+app.UseOpenTelemetryPrometheusScrapingEndpoint();
+```
+
+```bash
+dotnet add package OpenTelemetry.Exporter.Prometheus.AspNetCore
+```
+
+### Jaeger (Traces, Legacy)
+
+> Note: Jaeger now supports OTLP natively. Prefer the OTLP exporter for new setups.
+
+```csharp
+.WithTracing(tracing => tracing
+    .AddSource("MyApp.MyComponent")
+    .AddJaegerExporter(options =>
+    {
+        options.AgentHost = "localhost";
+        options.AgentPort = 6831;
+    }));
+```
+
+```bash
+dotnet add package OpenTelemetry.Exporter.Jaeger
+```
+
+### Zipkin (Traces)
+
+```csharp
+.WithTracing(tracing => tracing
+    .AddSource("MyApp.MyComponent")
+    .AddZipkinExporter(options =>
+    {
+        options.Endpoint = new Uri("http://zipkin:9411/api/v2/spans");
+    }));
+```
+
+```bash
+dotnet add package OpenTelemetry.Exporter.Zipkin
+```
+
+---
+
+## Instrumentation Libraries
+
+Instrumentation libraries automatically instrument common .NET libraries without
+modifying application code. Add them at the application composition root:
+
+| Library | Package | What it instruments |
+|---------|---------|-------------------|
+| ASP.NET Core | `OpenTelemetry.Instrumentation.AspNetCore` | Incoming HTTP requests (Server spans) |
+| HttpClient | `OpenTelemetry.Instrumentation.Http` | Outgoing HTTP calls (Client spans) |
+| SqlClient | `OpenTelemetry.Instrumentation.SqlClient` | SQL Server database calls (Client spans) |
+| .NET Runtime | `OpenTelemetry.Instrumentation.Runtime` | GC, thread pool, JIT, exception metrics |
+| Entity Framework Core | `OpenTelemetry.Instrumentation.EntityFrameworkCore` | EF Core database calls |
+| gRPC | `OpenTelemetry.Instrumentation.GrpcNetClient` | gRPC client calls |
+| StackExchange.Redis | `OpenTelemetry.Instrumentation.StackExchangeRedis` | Redis calls |
+| PostgreSQL (Npgsql) | `Npgsql.OpenTelemetry` | PostgreSQL database calls |
+
+### Example: Full Application Setup
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource
+        .AddService("myapp", serviceVersion: "1.0.0"))
+    .WithTracing(tracing => tracing
+        // Your custom ActivitySources
+        .AddSource("MyApp.OrderProcessing")
+        // Auto-instrumentation
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddSqlClientInstrumentation()
+        .AddEntityFrameworkCoreInstrumentation()
+        // Export
+        .AddOtlpExporter())
+    .WithMetrics(metrics => metrics
+        // Your custom Meters
+        .AddMeter("MyApp.OrderProcessing")
+        // Auto-instrumentation
+        .AddAspNetCoreInstrumentation()
+        .AddRuntimeInstrumentation()
+        // Export
+        .AddOtlpExporter());
+```
+
+### Filtering Instrumentation
+
+Filter out noisy spans (e.g., health checks):
+
+```csharp
+.WithTracing(tracing => tracing
+    .AddAspNetCoreInstrumentation(options =>
+    {
+        options.Filter = httpContext =>
+        {
+            // Don't trace health check endpoints
+            return !httpContext.Request.Path.StartsWithSegments("/health");
+        };
+    }))
+```
+
+---
+
+## Sampling
+
+[Sampling](https://opentelemetry.io/docs/specs/otel/trace/sdk/#sampling) controls
+which traces are recorded and exported. It reduces overhead and telemetry volume.
+Sampling decisions are typically made at trace start (head-based sampling) and
+propagated downstream via context.
+
+### How Sampling Affects Instrumentation Authors
+
+- Your spans may be sampled out — the `Activity` may be `null` even when
+  `HasListeners()` returns true (the SDK decides based on the sampler)
+- Always null-check `Activity` after `StartActivity`
+- Samplers can consider attributes set at span creation time — set key attributes
+  early if you want them to influence sampling decisions
+
+### Built-in Samplers (.NET SDK)
+
+The OTel .NET SDK defaults to `ParentBased(AlwaysOn)` — effectively always on,
+but respecting parent sampling decisions for child spans.
+
+| Sampler | Description |
+|---------|-------------|
+| `AlwaysOnSampler` | Records and samples every span |
+| `AlwaysOffSampler` | Drops every span |
+| `TraceIdRatioBasedSampler(ratio)` | Samples a fixed fraction of traces (0.0–1.0) |
+| `ParentBasedSampler(root)` | Follows parent's sampling decision (recommended production default) |
+
+### Configuring a Sampler in Code
+
+```csharp
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddSource("MyApp.MyComponent")
+    // Use ParentBased with TraceIdRatioBased for root spans
+    .SetSampler(new ParentBasedSampler(
+        new TraceIdRatioBasedSampler(0.1)))  // 10% of root spans
+    .AddOtlpExporter()
+    .Build();
+```
+
+### With AddOpenTelemetry()
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddSource("MyApp.MyComponent")
+        .SetSampler(new ParentBasedSampler(
+            new TraceIdRatioBasedSampler(0.1)))
+        .AddOtlpExporter());
+```
+
+### Configuring via Environment Variables
+
+```bash
+# Always sample (default)
+export OTEL_TRACES_SAMPLER=always_on
+
+# Never sample
+export OTEL_TRACES_SAMPLER=always_off
+
+# Ratio-based sampling (10%)
+export OTEL_TRACES_SAMPLER=traceidratio
+export OTEL_TRACES_SAMPLER_ARG=0.1
+
+# Parent-based with ratio for roots
+export OTEL_TRACES_SAMPLER=parentbased_traceidratio
+export OTEL_TRACES_SAMPLER_ARG=0.1
+```
+
+### ParentBased Explained
+
+`ParentBased` is the recommended production sampler. It delegates to sub-samplers
+based on the parent context:
+
+| Parent State | Sampler Invoked | Default |
+|-------------|-----------------|---------|
+| No parent (root span) | `root` | You configure this |
+| Remote parent, sampled | `remoteParentSampled` | AlwaysOn |
+| Remote parent, not sampled | `remoteParentNotSampled` | AlwaysOff |
+| Local parent, sampled | `localParentSampled` | AlwaysOn |
+| Local parent, not sampled | `localParentNotSampled` | AlwaysOff |
+
+This ensures child spans follow their parent's sampling decision, maintaining
+trace completeness. Only root spans are subject to the ratio-based decision.
+
+### Custom Sampler
+
+Implement a custom sampler by extending `Sampler`:
+
+```csharp
+public class HealthCheckExcludingSampler : Sampler
+{
+    private readonly TraceIdRatioBasedSampler _fallback;
+
+    public HealthCheckExcludingSampler(double ratio)
+    {
+        _fallback = new TraceIdRatioBasedSampler(ratio);
+    }
+
+    public override SamplingResult ShouldSample(in SamplingParameters parameters)
+    {
+        // Drop health check spans entirely
+        if (parameters.Name != null && parameters.Name.Contains("health"))
+        {
+            return new SamplingResult(SamplingDecision.Drop);
+        }
+
+        // Delegate to ratio-based for everything else
+        return _fallback.ShouldSample(parameters);
+    }
+}
+```
+
+```csharp
+.SetSampler(new ParentBasedSampler(new HealthCheckExcludingSampler(0.1)))
+```
+
+### Head-Based vs. Tail-Based Sampling
+
+**Head-based sampling** (default in OTel): the sampling decision is made when the
+trace starts, at the root span. All child spans inherit the decision. Simple,
+low-overhead, but you can't sample based on downstream information (e.g., "keep
+all traces that had an error").
+
+**Tail-based sampling**: the decision is made after the trace completes, based on
+the full trace data. This allows sampling rules like "keep 100% of error traces,
+10% of successful traces." Tail-based sampling is typically implemented in the
+[OTel Collector](https://opentelemetry.io/docs/collector/), not in the SDK.
+
+For .NET-specific tail-based sampling patterns, see
+[OTel .NET: Tail-Based Sampling](https://opentelemetry.io/docs/languages/dotnet/traces/tail-based-sampling/).
+
+---
+
+## Logs
+
+OpenTelemetry logs integrate with the built-in `Microsoft.Extensions.Logging.ILogger`
+API. The OTel SDK provides `AddOpenTelemetry()` on the logging builder to collect,
+process, and export log data.
+
+### How .NET Logs Work with OTel
+
+Per the [MS Learn documentation](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-with-otel),
+.NET provides logging APIs in the framework. OTel collects from these APIs and
+exports them:
+
+```
+ILogger.Log() → OpenTelemetry LoggerProvider → Processors → Exporters → Backend
+```
+
+### ASP.NET Core Setup
+
+```csharp
+builder.Logging.AddOpenTelemetry(options =>
+{
+    options.SetResourceBuilder(
+        ResourceBuilder.CreateDefault().AddService("myapp", serviceVersion: "1.0.0"));
+    options.AddOtlpExporter();
+    // Optional: include formatted log state as a field
+    options.IncludeFormattedMessage = true;
+    options.ParseStateValues = true;
+});
+```
+
+When using `AddOpenTelemetry()` on `builder.Services`, logs are configured separately
+on `builder.Logging`.
+
+### Log Correlation with Traces
+
+Logs are automatically correlated with traces. When a log is emitted within an active
+span, the OTel SDK includes the current `TraceId` and `SpanId` in the log record:
+
+```csharp
+// This log will automatically carry TraceId/SpanId from the current Activity
+logger.LogInformation("Processing order {OrderId} for customer {CustomerId}",
+    orderId, customerId);
+```
+
+The log record's `TraceId`/`SpanId` can be used in observability backends to filter
+logs by trace, jump from a trace to its logs, or correlate across services.
+
+### Structured Logging
+
+Use `ILogger` structured logging (template with named placeholders):
+
+```csharp
+// ✅ CORRECT: Structured logging with named placeholders
+logger.LogInformation("Order {OrderId} processed in {DurationMs}ms",
+    orderId, duration.TotalMilliseconds);
+
+// ❌ WRONG: String interpolation loses structure
+logger.LogInformation($"Order {orderId} processed in {duration.TotalMilliseconds}ms");
+```
+
+Structured logging preserves the semantic meaning of each parameter — backends can
+index, filter, and query by `OrderId` as a structured field, not just as text.
+
+### Log Redaction
+
+For sensitive data, implement a custom processor or use the logging pipeline:
+
+```csharp
+public class RedactingLogProcessor : BaseProcessor<LogRecord>
+{
+    private static readonly Regex EmailRegex = new(@"\b[\w.-]+@[\w.-]+\.\w+\b",
+        RegexOptions.Compiled);
+
+    public override void OnEnd(LogRecord record)
+    {
+        if (record.FormattedMessage != null)
+        {
+            // Redact email addresses
+            // Note: modify the record or drop it based on your needs
+        }
+    }
+}
+
+builder.Logging.AddOpenTelemetry(options =>
+{
+    options.AddProcessor(new RedactingLogProcessor());
+    options.AddOtlpExporter();
+});
+```
+
+See [OTel .NET: Log Redaction](https://opentelemetry.io/docs/languages/dotnet/logs/redaction/).
+
+### Severity and Filtering
+
+The OTel logs SDK supports severity-based filtering:
+
+```csharp
+builder.Logging.AddOpenTelemetry(options =>
+{
+    // Only export logs at Warning or above
+    options.AddOtlpExporter();
+});
+```
+
+Standard ASP.NET Core log level filtering applies:
+
+```csharp
+builder.Logging.AddFilter<OpenTelemetryLoggerProvider>("Microsoft", LogLevel.Warning);
+```
+
+The OTel spec also defines `LoggerConfig` with:
+- `enabled`: whether the logger is active (default: `true`)
+- `minimum_severity`: minimum severity number for processing
+- `trace_based`: drop logs associated with unsampled traces (default: `false`)
+
+### Dedicated Logging Pipeline
+
+You can route specific logs to a dedicated pipeline (e.g., audit logs to a separate
+backend):
+
+```csharp
+// Route audit logs to a separate OTLP destination
+builder.Logging.AddFilter("MyApp.Audit", logLevel => true)
+    .AddOpenTelemetry(options =>
+    {
+        options.AddOtlpExporter(o =>
+            o.Endpoint = new Uri("http://audit-collector:4317"));
+    });
+```
+
+See [OTel .NET: Dedicated Logging Pipeline](https://opentelemetry.io/docs/languages/dotnet/logs/dedicated-pipeline/).
+
+### Logging Complex Objects
+
+```csharp
+// Objects are serialized as structured fields
+logger.LogInformation("Order processed: {Order}", order);
+
+// For complex objects, use a custom converter or log individual fields
+logger.LogInformation("Order {OrderId} total: {Total:C} items: {ItemCount}",
+    order.Id, order.Total, order.Items.Count);
+```
+
+See [OTel .NET: Logging Complex Objects](https://opentelemetry.io/docs/languages/dotnet/logs/complex-objects/).
+
+---
+
+## Environment Variable Configuration
+
+The OTel SDK reads configuration from environment variables with the `OTEL_` prefix.
+These are useful for deployment without code changes.
+
+### General SDK Configuration
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `OTEL_SERVICE_NAME` | Service name | `myapp` |
+| `OTEL_RESOURCE_ATTRIBUTES` | Resource attributes (comma-separated) | `service.version=1.0.0,deployment.environment.name=prod` |
+| `OTEL_LOG_LEVEL` | SDK log level | `info` |
+
+### Traces
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `OTEL_TRACES_SAMPLER` | Sampler to use | `parentbased_traceidratio` |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler argument | `0.1` |
+| `OTEL_TRACES_EXPORTER` | Trace exporter | `otlp` |
+| `OTEL_BSP_SCHEDULE_DELAY` | Batch processor delay | `5000` |
+
+### Metrics
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `OTEL_METRICS_EXPORTER` | Metrics exporter | `otlp` |
+| `OTEL_METRICS_EXPORT_INTERVAL` | Export interval (ms) | `60000` |
+| `OTEL_DOTNET_EXPERIMENTAL_METRICS_CARDINALITY_LIMIT` | Max attribute combinations | `2000` |
+
+### Exporter (OTLP)
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint | `http://collector:4317` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Protocol | `grpc` or `http/protobuf` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Headers (comma-separated) | `key1=val1,key2=val2` |
+
+See the [full environment variable reference](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
+
+---
+
+## Zero-Code Instrumentation
+
+For applications where you cannot modify source code, use the
+[OpenTelemetry .NET Automatic Instrumentation](https://opentelemetry.io/docs/zero-code/net/).
+This injects instrumentation at runtime without code changes:
+
+```bash
+# Install
+curl -sSfL https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest/download/otel-dotnet-auto-install.sh -O
+sh ./otel-dotnet-auto-install.sh
+
+# Enable
+. $HOME/.otel-dotnet-auto/instrument.sh
+
+# Run with instrumentation
+OTEL_SERVICE_NAME=myapp OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317 ./MyApp
+```
+
+This is an alternative to manual SDK setup — useful for existing applications,
+brownfield deployments, and when source changes are not possible.
+
+---
+
+## References
+
+- [OTel .NET: Manual Instrumentation](https://opentelemetry.io/docs/languages/dotnet/instrumentation/)
+- [OTel .NET: Resources](https://opentelemetry.io/docs/languages/dotnet/resources/)
+- [OTel .NET: Sampling](https://opentelemetry.io/docs/languages/dotnet/sampling/)
+- [OTel .NET: Logs](https://opentelemetry.io/docs/languages/dotnet/logs/)
+- [OTel .NET: Exporters](https://opentelemetry.io/docs/languages/dotnet/exporters/)
+- [OTel Resource Specification](https://opentelemetry.io/docs/specs/otel/resource/)
+- [OTel Logs Specification](https://opentelemetry.io/docs/specs/otel/logs/)
+- [OTel Logs SDK Specification](https://opentelemetry.io/docs/specs/otel/logs/sdk/)
+- [OTel Tracing SDK: Sampling](https://opentelemetry.io/docs/specs/otel/trace/sdk/#sampling)
+- [OTel Configuration: SDK Environment Variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
+- [OTel .NET: Zero-Code Instrumentation](https://opentelemetry.io/docs/zero-code/net/)
+- [OTel .NET: Tail-Based Sampling](https://opentelemetry.io/docs/languages/dotnet/traces/tail-based-sampling/)
+- [OTel .NET: Stratified Sampling](https://opentelemetry.io/docs/languages/dotnet/traces/stratified-sampling/)
+- [OTel .NET: Log Redaction](https://opentelemetry.io/docs/languages/dotnet/logs/redaction/)
+- [OTel .NET: Dedicated Logging Pipeline](https://opentelemetry.io/docs/languages/dotnet/logs/dedicated-pipeline/)
+- [OTel .NET: Log Correlation](https://opentelemetry.io/docs/languages/dotnet/logs/correlation/)
+- [OTel .NET: Logging Complex Objects](https://opentelemetry.io/docs/languages/dotnet/logs/complex-objects/)
+- [OTel .NET: Export to Jaeger](https://opentelemetry.io/docs/languages/dotnet/traces/jaeger/)
+- [OTel .NET: Export to Prometheus](https://opentelemetry.io/docs/languages/dotnet/metrics/getting-started-prometheus-grafana/)
+- [OTel Semantic Conventions: Resource](https://opentelemetry.io/docs/specs/semconv/resource/)
+- [.NET Observability with OpenTelemetry (Microsoft Learn)](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-with-otel)

--- a/skills/opentelementry-dotnet-instrumentation/traces-and-propagation-reference.md
+++ b/skills/opentelementry-dotnet-instrumentation/traces-and-propagation-reference.md
@@ -521,10 +521,9 @@ catch (Exception ex)
             {
                 ["exception.type"] = ex.GetType().FullName,
                 ["exception.message"] = ex.Message,
-                // exception.stacktrace is Recommended per OTel spec, but can be large.
-                // Consider logging the full stack trace via ILogger instead and relying
-                // on trace-log correlation. The spec is moving toward log-based
-                // exception recording (OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN).
+                // exception.stacktrace is Recommended by the span-event convention.
+                // Include it unless size, sensitivity, or volume policy says otherwise.
+                // For high-volume handled exceptions, prefer ILogger with trace correlation.
                 // ["exception.stacktrace"] = ex.ToString()
             }
         ));
@@ -548,7 +547,7 @@ catch (HttpRequestException ex) when (ex.StatusCode != null)
         {
             ["exception.type"] = ex.GetType().FullName,
             ["exception.message"] = ex.Message,
-            // exception.stacktrace omitted here — log via ILogger instead
+            // Include exception.stacktrace unless size, sensitivity, or volume policy says otherwise
         }));
     }
     throw;
@@ -571,7 +570,7 @@ OTel SDK handles translation to the OTel span status fields automatically.
 
 ### Exception Event Attribute Reference
 
-Per the [OTel exception semantic conventions](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions_attributes/):
+Per the [OTel exception span conventions](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/):
 
 | Attribute | Required | Description |
 |-----------|----------|-------------|
@@ -593,5 +592,5 @@ Per the [OTel exception semantic conventions](https://opentelemetry.io/docs/spec
 - [W3C Baggage](https://www.w3.org/TR/baggage/)
 - [OTel .NET: Creating Links Between Traces](https://opentelemetry.io/docs/languages/dotnet/traces/links-creation/)
 - [OTel .NET: Reporting Exceptions](https://opentelemetry.io/docs/languages/dotnet/traces/reporting-exceptions/)
-- [OTel Exception Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions_attributes/)
+- [OTel Exception Span Conventions](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/)
 - [.NET Distributed Tracing Documentation](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing)

--- a/skills/opentelementry-dotnet-instrumentation/traces-and-propagation-reference.md
+++ b/skills/opentelementry-dotnet-instrumentation/traces-and-propagation-reference.md
@@ -1,0 +1,590 @@
+# Traces and Context Propagation Reference
+
+Detailed reference for OpenTelemetry tracing patterns in .NET, covering SpanKind
+selection, span links, context propagation, baggage, and exception recording.
+
+This is a companion to [SKILL.md](SKILL.md). See it for core principles and the
+"System.Diagnostics first" architecture.
+
+## Table of Contents
+
+- [SpanKind Deep Dive](#spankind-deep-dive)
+- [Span Links](#span-links)
+- [Context Propagation](#context-propagation)
+- [Baggage](#baggage)
+- [Nested Spans](#nested-spans)
+- [Full Exception Recording Pattern](#full-exception-recording-pattern)
+- [References](#references)
+
+---
+
+## SpanKind Deep Dive
+
+`ActivityKind` (called `SpanKind` in the OTel spec) clarifies a span's relationship
+to other spans. It describes two independent properties:
+
+1. Whether a span represents an **outgoing call** (`Client`/`Producer`) or
+   **incoming request processing** (`Server`/`Consumer`)
+2. Whether a span is a **request/response** (`Client`/`Server`) or
+   **deferred execution** (`Producer`/`Consumer`)
+
+A single span SHOULD NOT serve more than one purpose. If you need to describe both
+an incoming request and an outgoing call, create separate spans.
+
+### Internal (Default)
+
+In-process operations that do not cross a remote boundary.
+
+```csharp
+// ActivityKind.Internal is the default — both calls are equivalent
+using var activity = ActivitySource.StartActivity("ProcessItem", ActivityKind.Internal);
+// or simply: ActivitySource.StartActivity("ProcessItem");
+```
+
+**Use when**: the work happens entirely within the current process — business logic,
+data transformation, internal computation.
+
+### Server
+
+Processing an incoming remote request.
+
+```csharp
+// HTTP server handler
+using var activity = ActivitySource.StartActivity("HandleRequest", ActivityKind.Server);
+activity?.SetTag("http.request.method", "GET");
+activity?.SetTag("url.full", requestUrl);
+activity?.SetTag("server.address", "myapp.example.com");
+activity?.SetTag("server.port", 8080);
+```
+
+**Use when**: your code is the server side of a client/server interaction —
+HTTP handler, gRPC service, message queue consumer that acknowledges receipt.
+
+**Key**: the OTel SDK's ASP.NET Core instrumentation automatically creates `Server`
+spans for incoming HTTP requests. Only create your own `Server` span if you have a
+custom transport (e.g., raw TCP listener, custom protocol).
+
+### Client
+
+Making an outgoing remote request.
+
+```csharp
+// Outgoing HTTP call
+using var activity = ActivitySource.StartActivity("CallExternalApi", ActivityKind.Client);
+activity?.SetTag("http.request.method", "POST");
+activity?.SetTag("url.full", "https://api.example.com/orders");
+activity?.SetTag("server.address", "api.example.com");
+```
+
+**Use when**: your code is the client side of a client/server interaction —
+HTTP client call, database query, RPC invocation.
+
+**Key**: the OTel SDK's HttpClient instrumentation automatically creates `Client`
+spans for outgoing HTTP calls. Only create your own `Client` span for custom
+transports not covered by built-in instrumentation.
+
+**Guideline**: create the `Client` span **before** injecting the `SpanContext`
+into the outgoing request headers. This ensures the context propagation carries
+the correct trace parent.
+
+### Producer
+
+Sending a deferred/asynchronous message to a remote destination.
+
+```csharp
+// Publishing to a message queue
+using var activity = ActivitySource.StartActivity("PublishOrderEvent", ActivityKind.Producer);
+activity?.SetTag("messaging.system", "rabbitmq");
+activity?.SetTag("messaging.destination.name", "order.events");
+activity?.SetTag("messaging.operation.name", "publish");
+```
+
+**Use when**: your code sends a message that will be processed asynchronously
+later — message queue publish, event bus emit, job enqueue.
+
+The key difference from `Client`: a `Client` span expects a response (request/response),
+while a `Producer` span fires-and-forgets (deferred execution). The context is
+propagated so the downstream `Consumer` span can link back.
+
+### Consumer
+
+Receiving and processing a deferred/asynchronous message.
+
+```csharp
+// Consuming from a message queue
+using var activity = ActivitySource.StartActivity("ProcessOrderEvent", ActivityKind.Consumer);
+activity?.SetTag("messaging.system", "rabbitmq");
+activity?.SetTag("messaging.destination.name", "order.events");
+activity?.SetTag("messaging.operation.name", "receive");
+```
+
+**Use when**: your code receives a message that was previously produced by a
+`Producer` span — message queue consume, background job processing, event handler.
+
+The `Consumer` span's parent is typically the `Producer` span (propagated via context),
+creating a causal link across the asynchronous boundary.
+
+### SpanKind Decision Flowchart
+
+```
+Is the work entirely in-process?
+  → YES: ActivityKind.Internal
+  → NO:  Is this processing an incoming request?
+           → YES: Is it request/response (HTTP, gRPC, RPC)?
+                    → YES: ActivityKind.Server
+                    → NO (deferred/async): ActivityKind.Consumer
+           → NO (outgoing): Is it request/response?
+                    → YES: ActivityKind.Client
+                    → NO (deferred/async): ActivityKind.Producer
+```
+
+---
+
+## Span Links
+
+[Span links](https://opentelemetry.io/docs/specs/otel/overview/#links-between-spans)
+connect a span to other spans that are causally related but not in a direct
+parent-child relationship. Links can point to spans in the same trace or across
+different traces.
+
+### When to Use Links
+
+- **Batch processing**: a single span processes items from multiple upstream spans
+- **Scatter/gather (fork/join)**: a root span fans out to multiple operations, then
+  an aggregation span links back to all of them
+- **Trace boundary crossing**: when a new trace is created at a trust boundary,
+  link back to the originating trace
+- **Fan-in**: multiple incoming messages trigger a single processing span
+
+### Creating Links
+
+```csharp
+// ✅ CORRECT: Pass links at activity creation time
+// (samplers can only consider links present during span creation)
+var links = new List<ActivityLink>
+{
+    new(activityContext1),
+    new(activityContext2),
+    new(activityContext3)
+};
+
+var activity = MyActivitySource.StartActivity(
+    ActivityKind.Internal,
+    name: "batch-process",
+    links: links);
+```
+
+### Batch Processing Example
+
+```csharp
+// Each incoming item has its own trace context
+// The batch span links to all of them
+public async Task ProcessBatchAsync(List<ActivityContext> itemContexts)
+{
+    var links = itemContexts.Select(ctx => new ActivityLink(ctx)).ToList();
+
+    using var batchActivity = ActivitySource.StartActivity(
+        ActivityKind.Internal,
+        name: "ProcessBatch",
+        links: links);
+
+    if (batchActivity?.IsAllDataRequested == true)
+    {
+        batchActivity.SetTag("batch.item_count", itemContexts.Count);
+    }
+
+    foreach (var itemContext in itemContexts)
+    {
+        await ProcessItemAsync(itemContext);
+    }
+}
+```
+
+### Scatter/Gather Example
+
+```csharp
+// Fan out to multiple workers, then aggregate results
+public async Task<AggregatedResult> ScatterGatherAsync(List<Input> inputs)
+{
+    // Capture each worker's ActivityContext during execution
+    var results = await Task.WhenAll(inputs.Select(async input =>
+    {
+        using var workerActivity = ActivitySource.StartActivity("ProcessWorker", ActivityKind.Internal);
+        await ProcessWorkerAsync(input);
+        return (input, workerActivity?.Context);
+    }));
+
+    // The aggregation span links back to all worker spans
+    var links = results
+        .Where(r => r.Context != default)
+        .Select(r => new ActivityLink(r.Context))
+        .ToList();
+
+    using var aggregateActivity = ActivitySource.StartActivity(
+        ActivityKind.Internal,
+        name: "AggregateResults",
+        links: links);
+
+    return Aggregate(results.Select(r => r.input));
+}
+```
+
+### Trace Boundary Crossing
+
+When a service creates a new trace rather than trusting the incoming context
+(e.g., at a security/trust boundary), link back to the originating trace.
+To create a true root span, you must clear `Activity.Current` first — otherwise
+`StartActivity` will use the current activity as the parent:
+
+```csharp
+public async Task HandleUntrustedRequest(ActivityContext incomingContext)
+{
+    // Link to the incoming context
+    var links = new List<ActivityLink> { new(incomingContext) };
+
+    // Clear Activity.Current to force a root span (new trace)
+    var previousActivity = Activity.Current;
+    Activity.Current = null;
+    try
+    {
+        using var activity = ActivitySource.StartActivity(
+            ActivityKind.Server, name: "HandleRequest", links: links);
+
+        // This is now a root span linked to the incoming trace
+        await ProcessRequestAsync();
+    }
+    finally
+    {
+        Activity.Current = previousActivity; // restore context
+    }
+}
+```
+
+### Link Best Practices
+
+1. **Add links at creation time** — samplers can only consider links present during
+   span creation. Adding links later is possible but won't affect sampling.
+2. **Use links, not parent, for multi-origin spans** — the parent field represents a
+   single parent; links represent multiple causal relationships.
+3. **Don't set a parent for scatter/gather aggregation** — the aggregation span is
+   linked to many spans, not a child of any single one.
+4. **Use sparingly** — links add overhead; only use them when there is a genuine
+   causal relationship that parent/child doesn't capture.
+
+See [OTel .NET: Creating links between traces](https://opentelemetry.io/docs/languages/dotnet/traces/links-creation/).
+
+---
+
+## Context Propagation
+
+[Distributed tracing](https://opentelemetry.io/docs/specs/otel/context/) requires
+propagating trace context across process boundaries. In .NET, this is handled by
+`DistributedContextPropagator`, which serializes/deserializes the `SpanContext`
+(SpanContext portion) and `Baggage` into and out of carrier objects (HTTP headers,
+message metadata, etc.).
+
+### W3C TraceContext
+
+The default and recommended propagation format is [W3C TraceContext](https://www.w3.org/TR/trace-context/),
+which uses the `traceparent` and `tracestate` HTTP headers:
+
+```
+traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+             version-traceid-spanid-flags
+```
+
+The OTel .NET SDK configures W3C TraceContext propagation by default. .NET 7+ also
+defaults to W3C format for `Activity` ID format.
+
+### Automatic Propagation
+
+For standard transports (HttpClient, ASP.NET Core), propagation is automatic when
+using the OTel instrumentation libraries:
+
+```csharp
+// Application setup (NOT library code)
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddAspNetCoreInstrumentation()  // auto-extracts incoming context
+        .AddHttpClientInstrumentation()   // auto-injects outgoing context
+        .AddOtlpExporter());
+```
+
+With these, you do NOT need to manually propagate context for HTTP calls.
+
+### Manual Propagation (Custom Transports)
+
+For non-standard transports (raw TCP, custom protocols, message systems without
+built-in instrumentation), use the OTel SDK's `TextMapPropagator` (from
+`OpenTelemetry.Context.Propagation`, requires an OTel NuGet package at the
+application root) to manually inject/extract context:
+
+```csharp
+using OpenTelemetry.Context.Propagation;
+
+// ✅ Manual inject for outgoing call
+using var activity = ActivitySource.StartActivity("SendMessage", ActivityKind.Client);
+
+if (activity != null)
+{
+    var headers = new Dictionary<string, string>();
+    var propagator = Propagators.DefaultTextMapPropagator;
+    propagator.Inject(new PropagationContext(activity.Context, Baggage.Current),
+        headers,
+        static (carrier, name, value) => ((Dictionary<string, string>)carrier!)[name] = value!);
+
+    await SendMessageAsync(payload, headers);
+}
+```
+
+```csharp
+// ✅ Manual extract for incoming request
+var propagator = Propagators.DefaultTextMapPropagator;
+var extracted = propagator.Extract(default, incomingHeaders,
+    static (carrier, name) =>
+    {
+        if (((Dictionary<string, string>)carrier!).TryGetValue(name, out var value))
+            return new[] { value };
+        return null;
+    });
+
+// Create a server span with the extracted parent context
+using var activity = ActivitySource.StartActivity(
+    ActivityKind.Server,
+    name: "ReceiveMessage",
+    parentId: extracted.ActivityContext.TraceId != default
+        ? extracted.ActivityContext
+        : default);
+```
+
+For library code (no OTel packages), use the built-in `DistributedContextPropagator`
+APIs: `DistributedContextPropagator.Current.Inject(activity, carrier, setter)` for
+injection, and `DistributedContextPropagator.Current.ExtractTraceIdAndState(...)`
+for extraction. These use the same `traceparent` header format.
+
+### Custom Propagators
+
+You can configure which propagators are active. For example, to support both
+W3C TraceContext and Baggage propagation (the OTel default composite):
+
+```csharp
+// Application setup
+Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(
+    new TextMapPropagator[]
+    {
+        new TraceContextPropagator(),   // W3C traceparent
+        new BaggagePropagator()         // W3C baggage
+    }));
+```
+
+### B3 Propagator (Legacy Compatibility)
+
+If you need to interoperate with systems using the [B3 propagation format](https://github.com/openzipkin/b3-propagation)
+(Zipkin-style), install `OpenTelemetry.Extensions.Propagators` and configure:
+
+```csharp
+Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(
+    new TextMapPropagator[]
+    {
+        new TraceContextPropagator(),
+        new BaggagePropagator(),
+        new B3Propagator()  // legacy B3 multi-header format
+    }));
+```
+
+---
+
+## Baggage
+
+[Baggage](https://opentelemetry.io/docs/specs/otel/baggage/) is a mechanism for
+propagating name/value pairs across service boundaries within a distributed trace.
+It is intended for **observability correlation** — not for general-purpose
+application data transport.
+
+### When to Use Baggage
+
+- A web service needs to know what upstream service sent the request
+- A SaaS provider needs to include the API user/token responsible for a request
+- Correlating a failure to a specific browser version across services
+
+### When NOT to Use Baggage
+
+- Application business logic data (use your own headers/protocol)
+- Large payloads (baggage has size limits)
+- Security-sensitive data (baggage is not encrypted)
+
+### .NET Baggage API
+
+**Library code** (no OTel packages): use `Activity.Current?.SetBaggage()` —
+this is built into `System.Diagnostics.Activity`:
+
+```csharp
+// ✅ Set baggage in library code (no OTel package needed)
+Activity.Current?.SetBaggage("tenant.id", tenantId);
+Activity.Current?.SetBaggage("request.source", "mobile-app");
+```
+
+**Application code** (with OTel SDK): use `Baggage.Current` from
+`OpenTelemetry.Context.Baggage` — this provides a process-wide baggage API
+independent of the current Activity:
+
+```csharp
+using OpenTelemetry.Context.Baggage;
+
+// ✅ Read baggage in application code
+var tenantId = Baggage.Current.GetBaggage("tenant.id");
+var requestSource = Baggage.Current.GetBaggage("request.source");
+
+// Use baggage values as span attributes
+activity?.SetTag("tenant.id", tenantId);
+activity?.SetTag("request.source", requestSource);
+```
+
+Propagation happens automatically via the `BaggagePropagator` (configured as part
+of the default composite propagator).
+
+### Baggage Rules
+
+- Baggage keys and values are strings
+- Keys must match the pattern: `[a-z0-9][-a-z0-9._*]*[a-z0-9]` (lowercase)
+- The total baggage size SHOULD be limited (typically 180 characters per entry,
+  max 64 entries per the [W3C baggage spec](https://www.w3.org/TR/baggage/))
+- Baggage is propagated alongside trace context via the same HTTP headers mechanism
+- Do NOT use baggage for high-cardinality or sensitive data
+
+---
+
+## Nested Spans
+
+Nested spans track work that is hierarchical in nature. The parent/child relationship
+is established automatically via `AsyncLocal<Activity>` flow. Use explicit `using`
+blocks to control when each span ends — `Activity.Current` is restored to the
+parent when the inner `using` block disposes:
+
+```csharp
+public async Task ProcessOrderAsync(Order order)
+{
+    using (var parentActivity = ActivitySource.StartActivity("ProcessOrder", ActivityKind.Internal))
+    {
+        // Child span — parented to ProcessOrder via AsyncLocal
+        using (var childActivity = ActivitySource.StartActivity("ValidateOrder", ActivityKind.Internal))
+        {
+            await ValidateAsync(order);
+        } // childActivity disposed → Activity.Current restored to parentActivity
+
+        // Sibling span — also parented to ProcessOrder (not to ValidateOrder)
+        using (var dbActivity = ActivitySource.StartActivity("SaveOrder", ActivityKind.Internal))
+        {
+            await SaveAsync(order);
+        }
+    }
+}
+```
+
+**Rules**:
+- Parent/child is automatic — do not set `parentId` manually for in-process nesting
+- Use explicit `using` blocks (not `using var`) when you need the parent restored
+  before starting a sibling span
+- The child span's `ParentId` will be the parent's `SpanId`
+- Never start activities in fire-and-forget tasks where the `using` scope ends before
+  the work completes (the `AsyncLocal` context is lost when the task detaches)
+
+---
+
+## Full Exception Recording Pattern
+
+The modern .NET approach uses `Activity.SetStatus()` as the primary mechanism.
+The OTel SDK translates `ActivityStatusCode` into the proper OTel span status.
+
+### Basic Pattern
+
+```csharp
+try
+{
+    await ProcessItemAsync();
+    activity?.SetStatus(ActivityStatusCode.Ok);
+}
+catch (Exception ex)
+{
+    if (activity != null)
+    {
+        // Set error status with description
+        activity.SetStatus(ActivityStatusCode.Error, ex.Message);
+
+        // Record exception as an event per OTel semantic conventions
+        activity.AddEvent(new ActivityEvent(
+            "exception",
+            tags: new ActivityTagsCollection
+            {
+                ["exception.type"] = ex.GetType().FullName,
+                ["exception.message"] = ex.Message,
+                ["exception.stacktrace"] = ex.ToString()
+            }
+        ));
+    }
+    throw;
+}
+```
+
+### With Status Code Attributes
+
+For HTTP and other protocol handlers, also set the response status as a tag:
+
+```csharp
+catch (HttpRequestException ex) when (ex.StatusCode != null)
+{
+    if (activity != null)
+    {
+        activity.SetStatus(ActivityStatusCode.Error, ex.Message);
+        activity.SetTag("http.response.status_code", (int)ex.StatusCode);
+        activity.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
+        {
+            ["exception.type"] = ex.GetType().FullName,
+            ["exception.message"] = ex.Message,
+            ["exception.stacktrace"] = ex.ToString()
+        }));
+    }
+    throw;
+}
+```
+
+### Legacy Compatibility
+
+The manual `otel.status_code` and `otel.status_description` **tags** were required
+in early OTel .NET versions before `Activity.SetStatus()` was available:
+
+```csharp
+// ❌ LEGACY — no longer needed, prefer SetStatus
+activity.SetTag("otel.status_code", "error");
+activity.SetTag("otel.status_description", ex.Message);
+```
+
+Do NOT use these tags in new code. `Activity.SetStatus()` is the modern API and the
+OTel SDK handles translation to the OTel span status fields automatically.
+
+### Exception Event Attribute Reference
+
+Per the [OTel exception semantic conventions](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions_attributes/):
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| `exception.type` | Yes (if available) | Fully qualified exception type name |
+| `exception.message` | Yes (if available) | The exception message |
+| `exception.stacktrace` | Recommended | String representation of the stack trace |
+| `exception.escaped` | Optional | `true` if the exception escaped the span boundary |
+
+---
+
+## References
+
+- [OTel SpanKind Specification](https://opentelemetry.io/docs/specs/otel/trace/api/#spankind)
+- [OTel Links Between Spans](https://opentelemetry.io/docs/specs/otel/overview/#links-between-spans)
+- [OTel Link API](https://opentelemetry.io/docs/specs/otel/trace/api/#link)
+- [OTel Context Specification](https://opentelemetry.io/docs/specs/otel/context/)
+- [OTel Baggage Specification](https://opentelemetry.io/docs/specs/otel/baggage/)
+- [W3C Trace Context](https://www.w3.org/TR/trace-context/)
+- [W3C Baggage](https://www.w3.org/TR/baggage/)
+- [OTel .NET: Creating Links Between Traces](https://opentelemetry.io/docs/languages/dotnet/traces/links-creation/)
+- [OTel .NET: Reporting Exceptions](https://opentelemetry.io/docs/languages/dotnet/traces/reporting-exceptions/)
+- [OTel Exception Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions_attributes/)
+- [.NET Distributed Tracing Documentation](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing)

--- a/skills/opentelementry-dotnet-instrumentation/traces-and-propagation-reference.md
+++ b/skills/opentelementry-dotnet-instrumentation/traces-and-propagation-reference.md
@@ -83,9 +83,11 @@ HTTP client call, database query, RPC invocation.
 spans for outgoing HTTP calls. Only create your own `Client` span for custom
 transports not covered by built-in instrumentation.
 
-**Guideline**: create the `Client` span **before** injecting the `SpanContext`
-into the outgoing request headers. This ensures the context propagation carries
-the correct trace parent.
+**Guideline**: create the `Client` span **before** injecting its `SpanContext`
+into the outgoing request headers. If you inject first, `Activity.Current` still
+points to the parent span, so the parent's context propagates instead of the
+`Client` span's context. The `Client` span then ends up dangling — it exists in
+the trace but has no connection to the downstream call.
 
 ### Producer
 

--- a/skills/opentelementry-dotnet-instrumentation/traces-and-propagation-reference.md
+++ b/skills/opentelementry-dotnet-instrumentation/traces-and-propagation-reference.md
@@ -57,8 +57,8 @@ activity?.SetTag("server.address", "myapp.example.com");
 activity?.SetTag("server.port", 8080);
 ```
 
-**Use when**: your code is the server side of a client/server interaction —
-HTTP handler, gRPC service, message queue consumer that acknowledges receipt.
+**Use when**: your code is the server side of a request/response interaction —
+HTTP handler, gRPC service, RPC server, or custom protocol handler that sends a response.
 
 **Key**: the OTel SDK's ASP.NET Core instrumentation automatically creates `Server`
 spans for incoming HTTP requests. Only create your own `Server` span if you have a
@@ -99,12 +99,12 @@ activity?.SetTag("messaging.destination.name", "order.events");
 activity?.SetTag("messaging.operation.name", "publish");
 ```
 
-**Use when**: your code sends a message that will be processed asynchronously
-later — message queue publish, event bus emit, job enqueue.
+**Use when**: your code enqueues or publishes deferred work that will be processed
+asynchronously later — message queue publish, event bus emit, job enqueue.
 
 The key difference from `Client`: a `Client` span expects a response (request/response),
-while a `Producer` span fires-and-forgets (deferred execution). The context is
-propagated so the downstream `Consumer` span can link back.
+while a `Producer` span represents handing work to another component for later processing.
+The context is propagated so the downstream `Consumer` span can link back.
 
 ### Consumer
 
@@ -118,8 +118,9 @@ activity?.SetTag("messaging.destination.name", "order.events");
 activity?.SetTag("messaging.operation.name", "receive");
 ```
 
-**Use when**: your code receives a message that was previously produced by a
-`Producer` span — message queue consume, background job processing, event handler.
+**Use when**: your code dequeues, receives, or processes deferred work that was
+previously produced by a `Producer` span — message queue consume, background job
+processing, event handler, job dequeue.
 
 The `Consumer` span's parent is typically the `Producer` span (propagated via context),
 creating a causal link across the asynchronous boundary.

--- a/skills/opentelementry-dotnet-instrumentation/traces-and-propagation-reference.md
+++ b/skills/opentelementry-dotnet-instrumentation/traces-and-propagation-reference.md
@@ -521,7 +521,11 @@ catch (Exception ex)
             {
                 ["exception.type"] = ex.GetType().FullName,
                 ["exception.message"] = ex.Message,
-                ["exception.stacktrace"] = ex.ToString()
+                // exception.stacktrace is Recommended per OTel spec, but can be large.
+                // Consider logging the full stack trace via ILogger instead and relying
+                // on trace-log correlation. The spec is moving toward log-based
+                // exception recording (OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN).
+                // ["exception.stacktrace"] = ex.ToString()
             }
         ));
     }
@@ -544,7 +548,7 @@ catch (HttpRequestException ex) when (ex.StatusCode != null)
         {
             ["exception.type"] = ex.GetType().FullName,
             ["exception.message"] = ex.Message,
-            ["exception.stacktrace"] = ex.ToString()
+            // exception.stacktrace omitted here — log via ILogger instead
         }));
     }
     throw;


### PR DESCRIPTION
## What this is

The OpenTelemetry .NET instrumentation skill went from a single 477-line file (v1.0.0) to a 4-file skill suite (v2.0.0) that covers the OTel specification as it applies to .NET. I did extensive research against the [OTel spec](https://opentelemetry.io/docs/specs/otel/), the [.NET implementation docs](https://opentelemetry.io/docs/languages/dotnet/), and the [Microsoft Learn observability guide](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-with-otel) to find what was missing or wrong.

## Why I think this was needed

The original skill was a good starting point for traces and metrics, but I found three categories of problems.

### The skill never explained that .NET is different

This is the one I care about most. .NET ships its own tracing, metrics, and logging APIs in the framework (`System.Diagnostics.ActivitySource`, `System.Diagnostics.Metrics.Meter`, `Microsoft.Extensions.Logging.ILogger`). OTel NuGet packages are the collection and export layer, not a separate instrumentation API. Library authors need zero OTel packages.

The original skill conflated "instrumenting code" (framework APIs, no dependencies) with "running the OTel SDK" (NuGet packages, application-level). Its prerequisites said ".NET application with OpenTelemetry SDK," which is misleading for library authors.

The new skill opens with an "Architecture: .NET Is Different" section that establishes `System.Diagnostics.*` as the primary API, includes a package decision table, and instructs the LLM to discuss trade-offs with the user before adding any OTel NuGet package. That last part was a specific request from the skill owner, and I think it is important because it prevents the model from casually pulling in dependencies that the consuming application should own.

### Signal coverage was incomplete

The original skill covered traces and metrics but missed or under-covered significant parts of the OTel specification:

| Topic | Before | After |
|-------|--------|-------|
| Logs | Not mentioned | ILogger integration, log correlation, redaction, structured logging, severity filtering |
| Resource | Not mentioned | ResourceBuilder, AddService/AddAttributes/AddDetector, custom IResourceDetector |
| Context propagation | Not mentioned | W3C traceparent, TextMapPropagator, manual inject/extract, custom propagators, B3 legacy |
| Baggage | Not mentioned | Activity.SetBaggage (library) vs Baggage.Current (app), when to use, size limits |
| Span links | Not mentioned | Batch processing, scatter/gather, trace boundary crossing |
| SpanKind | Only Internal shown in passing | Full 5-kind table with decision flowchart and per-kind examples |
| Sampling | Not mentioned | Built-in samplers, custom Sampler, ParentBased, head vs tail, env vars |
| SDK setup | Assumed but never shown | ASP.NET Core + Console initialization, exporters, instrumentation libraries |
| Metric instruments | Only Counter + Histogram (2 of 7) | All 7 instrument types with creation/recording code and when-to-use |
| Exemplars | Passing mention | What they are, how to enable, reservoirs, metric-to-trace correlation |

### Two factual errors

The skill stated "All attributes must be non-null, non-empty strings." This contradicts the [OTel AnyValue spec](https://opentelemetry.io/docs/specs/otel/common/#anyvalue), which supports string, boolean, double, int64, byte arrays, homogeneous arrays, and null/empty values. The spec explicitly says these "MUST be stored and passed to exporters." I corrected this.

The exception recording pattern used the legacy `otel.status_code` / `otel.status_description` tags. The modern approach is `Activity.SetStatus(ActivityStatusCode.Error, description)`, which the OTel SDK translates to span status. I updated the pattern and noted the tags are no longer needed.

## What changed

### File structure

```
skills/opentelementry-dotnet-instrumentation/
├── SKILL.md                                    (498 lines, core, loaded by default)
├── traces-and-propagation-reference.md         (589 lines, SpanKind, links, propagation, baggage)
├── metrics-and-instruments-reference.md        (573 lines, all 7 instruments, dimensions, exemplars)
└── sdk-resources-and-logs-reference.md         (797 lines, SDK setup, resources, exporters, sampling, logs)
```

I followed the same progressive-disclosure pattern as `csharp-coding-standards` (5 files) and `r3-reactive-extensions` (4 files). SKILL.md is self-contained with enough context for basic usage. Reference files add depth when the model needs it.

### SKILL.md (rewritten)

New "Architecture: .NET Is Different" section with package decision table and user-tradeoff directive. Fixed the attribute value type error. Fixed the status/exception recording to use `SetStatus`. Added SpanKind selection table and instrument type overview table. Added Span Links, Context Propagation, and Logs sections with pointers to the reference files.

The Core Principles, Performance Requirements, Testing Requirements, and Versioning sections are unchanged. Those were already good, and I did not want to touch what was working.

### traces-and-propagation-reference.md (new)

SpanKind deep dive with per-kind .NET examples and a decision flowchart. Span Links with batch processing, scatter/gather, and trace boundary crossing patterns. Context propagation with W3C TraceContext, OTel TextMapPropagator for manual inject/extract, custom propagators, and B3 legacy. Baggage split into the library path (Activity.SetBaggage, no package) and the application path (Baggage.Current, OTel SDK). Nested spans using explicit `using` blocks for correct parent/sibling hierarchy. Full modern exception recording pattern.

### metrics-and-instruments-reference.md (new)

All 7 instrument types with creation code, recording code, and when-to-use guidance. Observable instrument callback patterns. Dimensions deep dive with cardinality management and high-cardinality opt-in pattern. Exemplars, aggregation defaults, Views for overriding, and units guidance with UCUM notation.

### sdk-resources-and-logs-reference.md (new)

SDK initialization for ASP.NET Core and Console. Resources with ResourceBuilder, AddService, AddAttributes, custom IResourceDetector, and env var configuration. Exporters (OTLP, Console, Prometheus, Jaeger, Zipkin). Instrumentation libraries with filtering. Sampling with built-in samplers, ParentBased explained, custom Sampler implementation, env vars, and head vs tail. Logs with ILogger integration, log correlation, structured logging, redaction, dedicated pipelines, and severity filtering. Environment variable reference tables.

## Quality assurance

I reviewed the skill against the [Anthropic skill-creator guidelines](https://github.com/anthropics/skills/tree/main/skills/skill-creator) and the [Claude Platform skill best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices).

A critical code-level review via subagent found 9 critical issues (fabricated APIs, compile errors, incorrect async/AsyncLocal claims, wrong span hierarchy), 4 high issues (broken scatter/gather pattern, baggage API requiring wrong package, URL inconsistencies, missing null-checks), and 4 medium issues (duplicate variable declarations, imprecise sampler defaults, old redirecting URLs, missing exporter in description). I fixed all of them.

SKILL.md is under 500 lines. Frontmatter name is lowercase-hyphens. Reference files over 300 lines have a table of contents. No deeply nested references (reference files only link back to SKILL.md).

## Checklist

* [x] I have reviewed my own pull request.
* [x] Changes in public API reviewed, if any. (N/A, skill content only, no code changes)