### PR TITLE
Release v1.5.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Comprehensive .NET development skills and agents for Claude Code - covering C#, F#, Akka.NET, Aspire, testing frameworks, and specialized tools",
   "author": {
     "name": "Aaron Stannard",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotnet-skills",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Professional .NET development skills for Codex - covering C#, F#, Akka.NET, Aspire, testing frameworks, and specialized tools",
   "author": {
     "name": "Aaron Stannard",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify tag matches manifest version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PLUGIN_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+          CODEX_VERSION=$(jq -r '.version' .codex-plugin/plugin.json)
+          echo "Tag version: v$TAG_VERSION"
+          echo "Claude manifest version: $PLUGIN_VERSION"
+          echo "Codex manifest version: $CODEX_VERSION"
+          if [ "$TAG_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "ERROR: Tag v$TAG_VERSION does not match .claude-plugin/plugin.json version $PLUGIN_VERSION"
+            echo "       Run ./scripts/bump-version.sh $TAG_VERSION before tagging."
+            exit 1
+          fi
+          if [ "$TAG_VERSION" != "$CODEX_VERSION" ]; then
+            echo "ERROR: Tag v$TAG_VERSION does not match .codex-plugin/plugin.json version $CODEX_VERSION"
+            echo "       Run ./scripts/bump-version.sh $TAG_VERSION before tagging."
+            exit 1
+          fi
+
       - name: Generate release notes
         run: |
           VERSION=$(jq -r '.version' .claude-plugin/plugin.json)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,9 +89,9 @@ When adding a skill with a **new prefix pattern**, update `scripts/generate-skil
 ## Marketplace Publishing
 
 **To publish a release:**
-1. Update version in `.claude-plugin/plugin.json` **and** `.codex-plugin/plugin.json` — they must match (CI enforces this via `scripts/validate-codex-plugin.sh`)
-2. Push a semver tag: `git tag v1.0.0 && git push origin v1.0.0`
-3. GitHub Actions creates the release automatically
+1. Bump versions with `./scripts/bump-version.sh <version>` — updates `.claude-plugin/plugin.json` **and** `.codex-plugin/plugin.json` together and runs the lockstep validator. Never edit the version fields by hand.
+2. Update `RELEASE_NOTES.md`
+3. Push a semver tag: `git tag v<version> && git push origin v<version>` — CI verifies the tag matches both manifests, then creates the release automatically
 
 **Users install with:**
 ```bash

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,32 @@
 # Release Notes
 
+## v1.5.0 (2026-08-07)
+
+### New Skills
+
+- **csharp-nullable-reference-types** - Added a progressive-disclosure skill for introducing and using nullable reference types (NRT) in C#/.NET codebases. Covers the nullability model and flow analysis, the null-forgiving operator, API design rules, the full `System.Diagnostics.CodeAnalysis` attribute catalog (AllowNull, DisallowNull, MaybeNull, NotNull, NotNullWhen, MaybeNullWhen, NotNullIfNotNull, MemberNotNull, MemberNotNullWhen, DoesNotReturn, DoesNotReturnIf), the C# 14 `field` keyword, and incremental migration of legacy codebases. Sibling reference files cover the NRT migration playbook and the nullable-attributes catalog with a code-generation checklist. ([#74](https://github.com/Aaronontheweb/dotnet-skills/pull/74))
+
+### Features
+
+- **OpenAI Codex plugin support** - Added a Codex plugin manifest, marketplace, and CI validation so the toolkit installs in OpenAI Codex (`codex plugin marketplace add Aaronontheweb/dotnet-skills`). Skills are auto-discovered from the `skills/` directory; the specialized agents remain Claude Code-specific. Release workflow now validates the Codex manifest and publishes Codex install instructions. ([#76](https://github.com/Aaronontheweb/dotnet-skills/pull/76))
+
+### Skill Enhancements
+
+- **opentelemetry-dotnet-instrumentation: exception recording & propagation corrections** - Corrected span status handling (leave status Unset on success; use `SetStatus(Error)` + `error.type` tag on exception), added dual-emission guidance for exception span events + `ILogger` logs with the `OTEL_SEMCONV_EXCEPTION_SIGNAL_OPT_IN` opt-in and a 6-month minimum dual-emission window, and documented a library error-reporting callback pattern for libraries without a logging dependency. Traces reference clarified SpanKind sync-vs-async semantics, corrected the messaging semconv (`receive` is kind Client, only `process` is Consumer), documented both Consumer-parenting options, and fixed manual context extraction to propagate `TraceState`. ([#72](https://github.com/Aaronontheweb/dotnet-skills/pull/72))
+
+### Documentation Improvements
+
+- **README: Codex installation + structure docs** - Updated branding to "for Claude Code and Codex", added Codex install instructions, and refreshed the repo-structure tree and contribution workflow. ([#76](https://github.com/Aaronontheweb/dotnet-skills/pull/76))
+- **Marketplace description update** - Refreshed the marketplace description to reflect new skills. ([#73](https://github.com/Aaronontheweb/dotnet-skills/pull/73))
+
+### Internal
+
+- **bump-version.sh** - Added a release script that bumps the version in both plugin manifests in lockstep, plus a CI guard that fails a tag push if the tag doesn't match the manifest version. ([#76](https://github.com/Aaronontheweb/dotnet-skills/pull/76))
+- **AGENTS.md canonical + CLAUDE.md symlink** - Expanded AGENTS.md into full contributor guidance; CLAUDE.md is now a symlink to it. ([#77](https://github.com/Aaronontheweb/dotnet-skills/pull/77))
+- **generate-release-summary.sh** - Added maintainer tooling to summarize new/updated skills and agents since a tag. ([#71](https://github.com/Aaronontheweb/dotnet-skills/pull/71))
+
+---
+
 ## v1.4.1 (2026-07-03)
 
 ### Skill Enhancements

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# bump-version.sh <new-version>
+# Bumps the version in BOTH plugin manifests (.claude-plugin/plugin.json and
+# .codex-plugin/plugin.json) so they stay in lockstep, then runs the Codex
+# validator to prove nothing drifted. Run this at the start of a release:
+#
+#   ./scripts/bump-version.sh 1.5.0
+#
+# It intentionally does NOT touch RELEASE_NOTES.md or commit — the release
+# workflow still owns those steps.
+
+set -euo pipefail
+
+NEW_VERSION="${1:?Usage: $0 <new-version>}"
+
+# Must be plain semver (the repo's CI only triggers on v-prefixed tags, so
+# this is the bare version, e.g. 1.5.0, not v1.5.0)
+if ! echo "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+  echo "ERROR: '$NEW_VERSION' is not valid semver (expected e.g. 1.5.0)" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+MANIFESTS=(
+  "$REPO_ROOT/.claude-plugin/plugin.json"
+  "$REPO_ROOT/.codex-plugin/plugin.json"
+)
+
+for manifest in "${MANIFESTS[@]}"; do
+  if [ ! -f "$manifest" ]; then
+    echo "ERROR: Missing manifest: $manifest" >&2
+    exit 1
+  fi
+  OLD_VERSION=$(jq -r '.version' "$manifest")
+  jq --arg v "$NEW_VERSION" '.version = $v' "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+  echo "Bumped $(basename "$(dirname "$manifest")")/$(basename "$manifest"): $OLD_VERSION -> $NEW_VERSION"
+done
+
+echo ""
+echo "Running Codex validator (lockstep check)..."
+bash "$SCRIPT_DIR/validate-codex-plugin.sh"
+
+echo ""
+echo "Done. Next: update RELEASE_NOTES.md and commit."


### PR DESCRIPTION
## Release v1.5.0

Bumps both plugin manifests to 1.5.0 in lockstep (via new `scripts/bump-version.sh`) and updates release notes.

### Highlights
- **New skill:** csharp-nullable-reference-types (#74)
- **Codex plugin support** - install with `codex plugin marketplace add Aaronontheweb/dotnet-skills` (#76)
- **OTel skill overhaul** - exception recording, span status, propagation corrections (#72)
- **bump-version.sh + CI tag guard** - versions can no longer drift or ship mismatched tags

Full notes in RELEASE_NOTES.md. Tag v1.5.0 will follow merge.