### PR TITLE
Wire release summary script into CI release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,13 @@ jobs:
 
           HEADER
 
-          echo "This release includes **$SKILLS skills** and **$AGENTS agents** for .NET development." >> notes.md
+          # Use the release summary script for new/updated counts when we have a previous tag
+          if [ -n "$PREV_TAG" ]; then
+            SUMMARY=$(bash ./scripts/generate-release-summary.sh "$PREV_TAG")
+            echo "$SUMMARY" >> notes.md
+          else
+            echo "This release includes **$SKILLS skills** and **$AGENTS agents** for .NET development." >> notes.md
+          fi
           echo "" >> notes.md
 
           # List skills by category


### PR DESCRIPTION
## What

The `generate-release-summary.sh` script (added in #71) computes new/updated skill and agent counts for release notes, but the release workflow never called it — so GitHub releases still showed only totals (e.g. "36 skills and 6 agents") instead of "36 skills (1 new 1 updated) and 6 agents".

This wires the script into the `Generate release notes` step of `release.yml`:

- When a previous tag exists (`git describe HEAD^`), call the script and use its summary line.
- When there's no previous tag (first release), fall back to the plain totals line.

Closes #62.

## Verification

- `generate-release-summary.sh v1.4.1` produces: `This release includes **36 skills (1 new 1 updated)** and **6 agents** for .NET development.`
- Simulated the exact workflow path on a tagged checkout: `PREV_TAG=v1.4.1` resolves correctly and the script runs.
- YAML validated.